### PR TITLE
Perfect Drawer behavior for mobile & desktop

### DIFF
--- a/src/admin/AdminLayout.js
+++ b/src/admin/AdminLayout.js
@@ -8,6 +8,8 @@ import Header from './project/layout/Header'
 import COLORS from '../constants/colors'
 import Container from '@material-ui/core/Container'
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core'
+import useTheme from '@material-ui/core/styles/useTheme'
+import useMediaQuery from '@material-ui/core/useMediaQuery/useMediaQuery'
 
 const innerTheme = createMuiTheme({
     palette: {
@@ -46,6 +48,28 @@ function AdminLayout(props) {
         }
     }, [])
 
+    const theme = useTheme()
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+    const [state, setState] = React.useState({
+        drawerOpen: !isMobile
+    })
+
+    const toggleDrawer = open => event => {
+        if (
+            event.type === 'keydown' &&
+            (event.key === 'Tab' || event.key === 'Shift')
+        ) {
+            return
+        }
+
+        if (!isMobile) {
+            // Menu always open is mobile
+            return
+        }
+
+        setState({ ...state, drawerOpen: open })
+    }
+
     return (
         <Box
             flex
@@ -55,9 +79,19 @@ function AdminLayout(props) {
             height="100vh"
             background={COLORS.ADMIN_BACKGROUND_LIGHT}
         >
-            <SideBar match={match} className={classes.sidebar} />
+            <SideBar
+                match={match}
+                className={classes.sidebar}
+                drawerOpen={state.drawerOpen}
+                isMobile={isMobile}
+                toggleDrawer={toggleDrawer(false)}
+            />
+
             <div className={classes.sidebar} ref={scrollRef}>
-                <Header refTarget={scrollTargetRef} />
+                <Header
+                    refTarget={scrollTargetRef}
+                    toggleDrawer={toggleDrawer(true)}
+                />
 
                 <Container maxWidth="lg" className={classes.container}>
                     <MuiThemeProvider theme={innerTheme}>

--- a/src/admin/project/layout/Header.js
+++ b/src/admin/project/layout/Header.js
@@ -20,6 +20,9 @@ import Button from '@material-ui/core/Button'
 import Menu from '@material-ui/core/Menu'
 import RoutingMap from '../../RoutingMap'
 import { withRouter } from 'react-router-dom'
+import Hidden from '@material-ui/core/Hidden'
+import IconButton from '@material-ui/core/IconButton'
+import MenuIcon from '@material-ui/icons/Menu'
 
 const innerTheme = createMuiTheme({
     palette: {
@@ -102,7 +105,8 @@ class Header extends Component {
             projects,
             selectedProject,
             selectedProjectId,
-            location
+            location,
+            toggleDrawer
         } = this.props
 
         const menuId = 'primary-project-selection-menu'
@@ -120,6 +124,16 @@ class Header extends Component {
                                 >
                                     <Grid container justify="space-between">
                                         <Grid item xs={12} sm={8}>
+                                            <Hidden mdUp>
+                                                <IconButton
+                                                    onClick={event =>
+                                                        toggleDrawer(event)
+                                                    }
+                                                >
+                                                    <MenuIcon />
+                                                </IconButton>
+                                            </Hidden>
+
                                             {selectedProject && (
                                                 <Button
                                                     aria-label="change event"

--- a/src/admin/project/layout/SideBar.js
+++ b/src/admin/project/layout/SideBar.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { COLORS } from '../../../constants/colors'
 import logo from '../../../assets/logo-openfeedback-color&white.png'
-import { connect } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { getUserSelector } from '../../auth/authSelectors'
-import { didSignIn, signOut } from '../../auth/authActions'
-import { createMuiTheme, withStyles } from '@material-ui/core'
+import { signOut } from '../../auth/authActions'
+import { createMuiTheme } from '@material-ui/core'
 import { MuiThemeProvider } from '@material-ui/core/styles'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
@@ -23,10 +23,11 @@ import RecordVoiceOverIcon from '@material-ui/icons/RecordVoiceOver'
 import SettingsIcon from '@material-ui/icons/Settings'
 import SlideshowIcon from '@material-ui/icons/Slideshow'
 import IconButton from '@material-ui/core/IconButton'
-import { authProvider } from '../../../firebase'
 import OFMenuItem from './OFMenuItem'
 import { getSelectedProjectIdSelector } from '../core/projectSelectors'
 import RoutingMap from '../../RoutingMap'
+import Drawer from '@material-ui/core/Drawer'
+import makeStyles from '@material-ui/core/styles/makeStyles'
 
 const innerTheme = createMuiTheme({
     palette: {
@@ -34,19 +35,20 @@ const innerTheme = createMuiTheme({
     }
 })
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
     container: {
         display: 'flex',
         flexDirection: 'column',
         background: COLORS.ADMIN_BACKGROUND,
         height: '100vh',
         minWidth: '220px',
-        [theme.breakpoints.up(900 + theme.spacing(6))]: {
-            width: 300
-        },
         '& .active': {
             background: COLORS.RED_ORANGE
         }
+    },
+    drawer: {
+        position: 'relative',
+        width: 270
     },
     list: {
         padding: 15,
@@ -67,18 +69,30 @@ const styles = theme => ({
     userBox: {
         marginTop: 'auto'
     }
-})
+}))
 
-class SideBar extends Component {
-    render() {
-        const { classes, user, match, selectedProjectId } = this.props
+const SideBar = ({ match, drawerOpen, toggleDrawer, isMobile }) => {
+    const dispatch = useDispatch()
+    const classes = useStyles()
 
-        const userName =
-            user.providerData[0] && user.providerData[0].displayName
+    const user = useSelector(getUserSelector)
+    const selectedProjectId = useSelector(getSelectedProjectIdSelector)
 
-        return (
-            <MuiThemeProvider theme={innerTheme}>
+    const userName = user.providerData[0] && user.providerData[0].displayName
+
+    return (
+        <MuiThemeProvider theme={innerTheme}>
+            <Drawer
+                variant={isMobile ? undefined : 'persistent'}
+                open={drawerOpen}
+                onClose={event => toggleDrawer(event)}
+                anchor="left"
+                classes={{
+                    paper: classes.drawer
+                }}
+            >
                 <div className={classes.container}>
+                    {isMobile}
                     <List component="nav">
                         <ListItem className={classes.logoContainer}>
                             <img
@@ -94,6 +108,7 @@ class SideBar extends Component {
                         component="nav"
                         aria-label="Main menu"
                         className={classes.list}
+                        onClick={event => toggleDrawer(event)}
                         subheader={
                             <ListSubheader component="div">DATA</ListSubheader>
                         }
@@ -125,6 +140,7 @@ class SideBar extends Component {
                         component="nav"
                         aria-label="Settings menu"
                         className={classes.list}
+                        onClick={event => toggleDrawer(event)}
                         subheader={
                             <ListSubheader component="div">
                                 SETTINGS
@@ -182,7 +198,7 @@ class SideBar extends Component {
                                 <IconButton
                                     edge="end"
                                     aria-label="signout"
-                                    onClick={() => authProvider.signOut()}
+                                    onClick={() => dispatch(signOut())}
                                 >
                                     <PowerSettingsIcon />
                                 </IconButton>
@@ -190,25 +206,9 @@ class SideBar extends Component {
                         </ListItem>
                     </List>
                 </div>
-            </MuiThemeProvider>
-        )
-    }
+            </Drawer>
+        </MuiThemeProvider>
+    )
 }
 
-const mapStateToProps = state => ({
-    user: getUserSelector(state),
-    selectedProjectId: getSelectedProjectIdSelector(state)
-})
-
-const mapDispatchToProps = Object.assign(
-    {},
-    {
-        didSignIn: didSignIn,
-        signOut: signOut
-    }
-)
-
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(withStyles(styles)(SideBar))
+export default SideBar

--- a/src/admin/project/layout/SideBar.js
+++ b/src/admin/project/layout/SideBar.js
@@ -35,7 +35,7 @@ const innerTheme = createMuiTheme({
     }
 })
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles({
     container: {
         display: 'flex',
         flexDirection: 'column',
@@ -69,7 +69,7 @@ const useStyles = makeStyles(theme => ({
     userBox: {
         marginTop: 'auto'
     }
-}))
+})
 
 const SideBar = ({ match, drawerOpen, toggleDrawer, isMobile }) => {
     const dispatch = useDispatch()


### PR DESCRIPTION
Add a drawer to encapsulate the sidebar menu. 
When viewport is mobile, the menu is floating above the content + a hamburger icon allow it to be open or close in the header
When viewport is desktop, drawer is always visible as before

+ convert sidebar to functional component