### PR TITLE
Remove specific sort base on vote item type & add migrating script

### DIFF
--- a/scripts/update-voteItems-position.2020.v0.20.0.ts
+++ b/scripts/update-voteItems-position.2020.v0.20.0.ts
@@ -1,0 +1,47 @@
+/**
+ * VoteItems (voting form) position field is not always present. This was fine before as "text" item was always the last
+ * item (filtered on the front) but due to free choice of the type, position should be the only source of position.
+ * This migrate all voteItems , add a position if missing and set position "text" vote item to the last item.
+ * Migrate from v0.19.0 to v0.20.0
+ **/
+
+import './helpers/initFirestore'
+import { updateProjects } from './helpers/updates'
+
+interface VoteItem {
+    position: number
+    id: string
+    name: string
+    type: 'text' | 'boolean'
+}
+
+const main = async () => {
+    await updateProjects(async project => {
+        if (!project.voteItems || project.voteItems.length === 0) {
+            return null
+        }
+
+        // Two pass: first to add missing position, second to change "text" position of the end
+        return {
+            voteItems: project.voteItems
+                .sort((a: VoteItem, b: VoteItem) => {
+                    if (a.type === 'boolean' && b.type === 'text') {
+                        return -1
+                    }
+                    if (b.type === 'boolean' && a.type === 'text') {
+                        return 1
+                    }
+
+                    return a.position > b.position ? 1 : -1
+                })
+                .map((item: any, index: number) => {
+                    return {
+                        ...item,
+                        position: index,
+                    }
+                }),
+        }
+    })
+}
+
+main()

--- a/src/admin/project/settings/votingForm/votingFormSelectors.js
+++ b/src/admin/project/settings/votingForm/votingFormSelectors.js
@@ -15,7 +15,6 @@ export const getSortedVoteItemsSelector = createSelector(
     getVoteItemsSelector,
     voteItems =>
         voteItems.sort((a, b) => {
-            if (a.type === VOTE_TYPE_TEXT) return 1
             return a.position > b.position ? 1 : -1
         })
 )

--- a/src/admin/project/settings/votingForm/votingFormSelectors.js
+++ b/src/admin/project/settings/votingForm/votingFormSelectors.js
@@ -1,6 +1,5 @@
 import { getAdminStateSelector } from '../../../adminSelector'
 import { createSelector } from 'reselect'
-import { VOTE_TYPE_TEXT } from '../../../../core/contants'
 
 const getVotingForm = state => getAdminStateSelector(state).adminVotingForm
 

--- a/src/feedback/project/projectSelectors.js
+++ b/src/feedback/project/projectSelectors.js
@@ -39,7 +39,6 @@ export const getProjectVoteItemsOrderedSelector = createSelector(
             return []
         }
         return voteItems.sort((a, b) => {
-            if (a.type === VOTE_TYPE_TEXT) return 1
             return a.position > b.position ? 1 : -1
         })
     }

--- a/src/feedback/project/projectSelectors.js
+++ b/src/feedback/project/projectSelectors.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect'
-import { VOTE_TYPE_TEXT } from '../../core/contants'
 
 const getProjectState = state => state.project
 


### PR DESCRIPTION
- Include a new migration script (` scripts/update-voteItems-position.2020.v0.20.0.ts `)
- fix a bug where vote items was not only ordered by the position field but also by the type. The migration script add a missing position everywhere and place the "type=text" at the end (current behavior) everywhere. 