### PR TITLE
[Admin & Feedback] Optional talk start/end date time

### DIFF
--- a/src/admin/baseComponents/form/dateTimePicker/OFDateTimePicker.js
+++ b/src/admin/baseComponents/form/dateTimePicker/OFDateTimePicker.js
@@ -1,8 +1,16 @@
 import React from 'react'
 import { DateTimePicker } from '@material-ui/pickers'
 import OFInputForDateTimePicker from './OFInputForDateTimePicker'
+import { useTranslation } from 'react-i18next'
 
-const OFDateTimePicker = ({ field, form, ...other }) => {
+const OFDateTimePicker = ({
+    field,
+    form,
+    format,
+    initialFocusedDate,
+    ...other
+}) => {
+    const { t } = useTranslation()
     const currentError = form.errors[field.name]
 
     return (
@@ -11,8 +19,10 @@ const OFDateTimePicker = ({ field, form, ...other }) => {
             disabled={!!form.isSubmitting}
             name={field.name}
             value={field.value}
-            variant="inline"
-            format={field.format}
+            initialFocusedDate={initialFocusedDate}
+            clearable
+            format={format}
+            minutesStep={5}
             ampm={false}
             helperText={currentError}
             error={Boolean(currentError)}
@@ -25,6 +35,10 @@ const OFDateTimePicker = ({ field, form, ...other }) => {
             onBlur={field.onBlur}
             TextFieldComponent={OFInputForDateTimePicker}
             onChange={(date) => form.setFieldValue(field.name, date, false)}
+            autoComplete="off"
+            okLabel={t('common.pick')}
+            cancelLabel={t('common.cancel')}
+            clearLabel={t('common.clear')}
             {...other}
         />
     )

--- a/src/admin/baseComponents/form/dateTimePicker/OFInputForDateTimePicker.js
+++ b/src/admin/baseComponents/form/dateTimePicker/OFInputForDateTimePicker.js
@@ -11,6 +11,7 @@ const OFInputForDateTimePicker = ({
     onKeyDown,
     inputRef,
     disabled,
+    autoComplete,
 }) => {
     return (
         <OFInput
@@ -23,6 +24,7 @@ const OFInputForDateTimePicker = ({
             onKeyDown={onKeyDown}
             inputRef={inputRef}
             disabled={disabled}
+            autoComplete={autoComplete}
         />
     )
 }

--- a/src/admin/project/talks/TalkAddEditPanel.js
+++ b/src/admin/project/talks/TalkAddEditPanel.js
@@ -44,12 +44,8 @@ const TalkAddEditPanel = ({
                                 .required(t('talks.fieldTitleRequired')),
                             trackTitle: string().ensure(),
                             tags: array().of(string()),
-                            startTime: string()
-                                .trim()
-                                .required(t('talks.fieldStartTimeRequired')),
-                            endTime: string()
-                                .trim()
-                                .required(t('talks.fieldEndTimeRequired')),
+                            startTime: string().nullable().trim(),
+                            endTime: string().nullable().trim(),
                             speakers: array().of(string()),
                         })}
                         initialValues={
@@ -57,12 +53,8 @@ const TalkAddEditPanel = ({
                                 title: '',
                                 trackTitle: '',
                                 tags: [],
-                                startTime:
-                                    projectVoteStartTime ||
-                                    DateTime.local().toISO(),
-                                endTime:
-                                    projectVoteStartTime ||
-                                    DateTime.local().toISO(),
+                                startTime: null,
+                                endTime: null,
                                 speakers: [],
                             }
                         }
@@ -85,7 +77,12 @@ const TalkAddEditPanel = ({
                                     isSubmitting={isSubmitting}
                                 />
 
-                                <TalkStartEndTimeFields />
+                                <TalkStartEndTimeFields
+                                    defaultValue={
+                                        projectVoteStartTime ||
+                                        DateTime.local().toISO()
+                                    }
+                                />
 
                                 <OFFormControl
                                     name={t('talks.fieldTrack')}

--- a/src/admin/project/talks/TalkListItem.js
+++ b/src/admin/project/talks/TalkListItem.js
@@ -11,7 +11,7 @@ import TalkListItemSpeakerList from './TalkListItemSpeakerList'
 import Chip from '@material-ui/core/Chip'
 import { DateTime } from 'luxon'
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
     cell: {
         paddingRight: 12,
         [theme.breakpoints.down('sm')]: {
@@ -57,13 +57,17 @@ const TalkListItem = ({
                         variant="outlined"
                     />
                 )}
-                <Chip
-                    icon={<CalendarIcon />}
-                    size="small"
-                    label={DateTime.fromISO(item.startTime).toLocaleString()}
-                    style={{ marginBottom: item.startTime ? 5 : 0 }}
-                    variant="outlined"
-                />
+                {item.startTime && (
+                    <Chip
+                        icon={<CalendarIcon />}
+                        size="small"
+                        label={DateTime.fromISO(
+                            item.startTime
+                        ).toLocaleString()}
+                        style={{ marginBottom: item.startTime ? 5 : 0 }}
+                        variant="outlined"
+                    />
+                )}
             </Grid>
             <Grid item xs={12} sm={2} lg={2} className={classes.buttonCell}>
                 <IconButton aria-label="edit" onClick={() => onEdit(item)}>

--- a/src/admin/project/talks/TalkStartEndTimeFields.js
+++ b/src/admin/project/talks/TalkStartEndTimeFields.js
@@ -39,7 +39,6 @@ const TalkStartEndTimeFields = ({ defaultValue }) => {
                     name={startTimeFieldName}
                     format="FFF"
                     initialFocusedDate={defaultValue}
-                    autocomplete="off"
                     component={OFDateTimePicker}
                 />
             </OFFormControl>
@@ -50,7 +49,6 @@ const TalkStartEndTimeFields = ({ defaultValue }) => {
                 <Field
                     name={endTimeFieldName}
                     format="FFF"
-                    autocomplete="off"
                     component={OFDateTimePicker}
                 />
             </OFFormControl>

--- a/src/admin/project/talks/TalkStartEndTimeFields.js
+++ b/src/admin/project/talks/TalkStartEndTimeFields.js
@@ -6,12 +6,13 @@ import { useTranslation } from 'react-i18next'
 
 const startTimeFieldName = 'startTime'
 const endTimeFieldName = 'endTime'
-const TalkStartEndTimeFields = () => {
+const TalkStartEndTimeFields = ({ defaultValue }) => {
     const [startField, startMeta] = useField(startTimeFieldName)
     // eslint-disable-next-line no-unused-vars
     const [endField, endMeta, endHelpers] = useField(endTimeFieldName)
 
     useEffect(() => {
+        // Update end time if start time is touched and updated
         if (
             startField.value !== startMeta.initialValue &&
             !endMeta.touched &&
@@ -37,6 +38,8 @@ const TalkStartEndTimeFields = () => {
                 <Field
                     name={startTimeFieldName}
                     format="FFF"
+                    initialFocusedDate={defaultValue}
+                    autocomplete="off"
                     component={OFDateTimePicker}
                 />
             </OFFormControl>
@@ -47,6 +50,7 @@ const TalkStartEndTimeFields = () => {
                 <Field
                     name={endTimeFieldName}
                     format="FFF"
+                    autocomplete="off"
                     component={OFDateTimePicker}
                 />
             </OFFormControl>

--- a/src/admin/translations/languages/en.admin.json
+++ b/src/admin/translations/languages/en.admin.json
@@ -20,7 +20,9 @@
         "download": "Download",
         "close": "Close",
         "preview": "Preview",
+        "pick": "Pick",
         "or": "OR",
+        "clear": "Clear",
         "dropzone": {
             "image": {
                 "button": "Upload image",
@@ -243,11 +245,9 @@
     "talks": {
         "addTalks": "Add talks",
         "cannotChange": "Talks cannot be changed from OpenFeedback itself for this project. Refer to your external services configuration to do so.",
-        "fieldEndTime": "End time*",
-        "fieldEndTimeRequired": "The end time is required.",
+        "fieldEndTime": "End time",
         "fieldSpeakers": "Speaker(s)",
-        "fieldStartTime": "Start time*",
-        "fieldStartTimeRequired": "The start time is required.",
+        "fieldStartTime": "Start time",
         "fieldTags": "Tags",
         "fieldTitle": "Title*",
         "fieldTitleRequired": "The talk title is required.",

--- a/src/admin/translations/languages/fr.admin.json
+++ b/src/admin/translations/languages/fr.admin.json
@@ -20,7 +20,9 @@
         "close": "Fermer",
         "saved": "Sauvegarder",
         "preview": "Aperçu",
+        "pick": "Sélectionner",
         "or": "OU",
+        "clear": "Enlever",
         "dropzone": {
             "image": {
                 "button": "Charger une image",
@@ -243,11 +245,9 @@
     "talks": {
         "addTalks": "Ajouter des présentations",
         "cannotChange": "Les présentations ne peuvent pas être modifiées depuis OpenFeedback pour ce projet. Reportez-vous à la configuration de vos services externes pour le faire.",
-        "fieldEndTime": "Heure de fin*",
-        "fieldEndTimeRequired": "L'heure de fin est requise.",
+        "fieldEndTime": "Heure de fin",
         "fieldSpeakers": "Orateur·rice·s",
-        "fieldStartTime": "Heure de début*",
-        "fieldStartTimeRequired": "L'heure de début est requise.",
+        "fieldStartTime": "Heure de début",
         "fieldTags": "Mots clés",
         "fieldTitle": "Titre*",
         "fieldTitleRequired": "Le titre de la présentation est obligatoire.",

--- a/src/core/setupType/validation.js
+++ b/src/core/setupType/validation.js
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 
-const validate = async api => {
+const validate = async (api) => {
     let result = {
         dataAvailable: false,
         speakersObjectFound: false,
@@ -70,7 +70,7 @@ const validateTalks = (talks, speakers) => {
             talk: {
                 idValid: false,
                 titleValid: false,
-                startEndTimeValid: false,
+                startEndTimeValid: true,
                 trackTitleValid: false,
                 speakersValid: false,
                 noSpeakers: 0,
@@ -87,7 +87,7 @@ const validateTalks = (talks, speakers) => {
             talk: {
                 idValid: false,
                 titleValid: false,
-                startEndTimeValid: false,
+                startEndTimeValid: true,
                 trackTitleValid: false,
                 speakersValid: false,
                 noSpeakers: 0,
@@ -97,7 +97,7 @@ const validateTalks = (talks, speakers) => {
         }
     } else {
         let tempTalk
-        talkKeys.forEach(key => {
+        talkKeys.forEach((key) => {
             tempTalk = talks[key]
             if (tempTalk || typeof talks === 'object') {
                 result.talk.talkCount++
@@ -108,11 +108,11 @@ const validateTalks = (talks, speakers) => {
                 if (!tempTalk.title) {
                     result.talk.titleValid = false
                 }
-                if (!tempTalk.startTime || !tempTalk.endTime) {
-                    result.talk.startEndTimeValid = false
-                } else if (
-                    !DateTime.fromISO(tempTalk.startTime).isValid ||
-                    !DateTime.fromISO(tempTalk.endTime).isValid
+                if (
+                    (tempTalk.startTime &&
+                        !DateTime.fromISO(tempTalk.startTime).isValid) ||
+                    (tempTalk.endTime &&
+                        !DateTime.fromISO(tempTalk.endTime).isValid)
                 ) {
                     result.talk.startEndTimeValid = false
                 }
@@ -126,7 +126,7 @@ const validateTalks = (talks, speakers) => {
                 ) {
                     result.talk.speakersValid = false
                 } else {
-                    tempTalk.speakers.forEach(speakerId => {
+                    tempTalk.speakers.forEach((speakerId) => {
                         if (!speakers || !speakers[speakerId]) {
                             result.talk.speakersMissing++
                         }
@@ -142,7 +142,7 @@ const validateTalks = (talks, speakers) => {
     return result
 }
 
-const validateSpeakers = speakers => {
+const validateSpeakers = (speakers) => {
     const result = {
         speakersObjectFound: true,
         speaker: {
@@ -177,7 +177,7 @@ const validateSpeakers = speakers => {
         }
     } else {
         let speaker
-        speakerKeys.forEach(key => {
+        speakerKeys.forEach((key) => {
             speaker = speakers[key]
             result.speaker.speakerCount++
             if (key !== speaker.id) {

--- a/src/core/talks/talksUtils.js
+++ b/src/core/talks/talksUtils.js
@@ -3,10 +3,10 @@ import { DateTime } from 'luxon'
 export const formatTalksWithScheduledForHoverboardv2 = (talks, schedule) => {
     const formatedTalks = {}
 
-    schedule.forEach(day => {
+    schedule.forEach((day) => {
         const tracks = day.tracks
 
-        day.timeslots.forEach(timeslot => {
+        day.timeslots.forEach((timeslot) => {
             const startTime = DateTime.fromISO(
                 day.date + 'T' + timeslot.startTime
             ).toISO()
@@ -14,7 +14,7 @@ export const formatTalksWithScheduledForHoverboardv2 = (talks, schedule) => {
                 day.date + 'T' + timeslot.endTime
             ).toISO()
             timeslot.sessions.forEach((talk, index) => {
-                talk.items.forEach(id => {
+                talk.items.forEach((id) => {
                     if (!talks[id]) return
                     formatedTalks[id] = {
                         ...talks[id],
@@ -30,6 +30,12 @@ export const formatTalksWithScheduledForHoverboardv2 = (talks, schedule) => {
     return formatedTalks
 }
 
-export const getDateFromStartTime = startTime => {
-    return DateTime.fromISO(startTime).toFormat('yyyy-MM-dd')
+export const getDateFromStartTime = (startTime) => {
+    const dateTime = DateTime.fromISO(startTime)
+    if (dateTime.isValid) {
+        return dateTime.toFormat('yyyy-MM-dd')
+    }
+    return TALK_NO_DATE
 }
+
+export const TALK_NO_DATE = '0-no-date'

--- a/src/feedback/AppLayout.js
+++ b/src/feedback/AppLayout.js
@@ -22,6 +22,7 @@ import makeStyles from '@material-ui/core/styles/makeStyles'
 import { signIn } from './auth/authActions'
 import { getVotes } from './vote/voteActions'
 import { useTranslation } from 'react-i18next'
+import { TALK_NO_DATE } from '../core/talks/talksUtils'
 
 const useStyles = makeStyles((theme) => ({
     container: {
@@ -91,7 +92,11 @@ const AppLayout = ({ children }) => {
 
     useEffect(() => {
         const { date, projectId } = routerParams
-        if (!date && talkDates.length > 0) {
+        if (
+            !date &&
+            talkDates.length > 0 &&
+            !talkDates.includes(TALK_NO_DATE)
+        ) {
             history.replace(`/${projectId}/${talkDates[0]}`)
         }
     }, [routerParams, talkDates, history])

--- a/src/feedback/talk/Talk.js
+++ b/src/feedback/talk/Talk.js
@@ -31,17 +31,13 @@ import {
 
 import Grid from '@material-ui/core/Grid'
 import TalkVote from './TalkVote'
-import SpeakerList from '../speaker/SpeakerList'
 import LoaderMatchParent from '../../baseComponents/customComponent/LoaderMatchParent'
 import Error from '../../baseComponents/customComponent/Error'
 import Snackbar from '../../baseComponents/customComponent/Snackbar'
-import Title from '../layout/Title'
-import { COLORS } from '../../constants/colors'
 import { SPACING } from '../../constants/constants'
-import { DateTime } from 'luxon'
 import { VOTE_TYPE_BOOLEAN, VOTE_TYPE_TEXT } from '../../core/contants'
-import Box from '@material-ui/core/Box'
 import { withTranslation } from 'react-i18next'
+import TalkHeader from './TalkHeader'
 
 class Talk extends Component {
     componentDidMount() {
@@ -146,39 +142,7 @@ class Talk extends Component {
         }
         return (
             <div>
-                <Box marginBottom={4}>
-                    <Title variant="h2" color="textPrimary">
-                        {talk.title}
-                        <Box
-                            color={COLORS.GRAY}
-                            fontSize={20}
-                            marginLeft={1}
-                            component="span">
-                            {talk.tags &&
-                                talk.tags.map((tag, key) => (
-                                    <span key={key}>#{tag} </span>
-                                ))}
-                        </Box>
-                    </Title>
-                    <Box fontSize={16} color={COLORS.GRAY} marginBottom={2}>
-                        {DateTime.fromISO(talk.startTime, {
-                            setZone: true,
-                        }).toLocaleString({
-                            weekday: 'long',
-                            month: 'long',
-                            day: 'numeric',
-                        })}
-                        {' / '}
-                        {DateTime.fromISO(talk.startTime, { setZone: true })
-                            .setZone('local', { keepLocalTime: true })
-                            .toLocaleString(DateTime.TIME_SIMPLE)}
-                        {' - '}
-                        {DateTime.fromISO(talk.endTime, {
-                            setZone: true,
-                        }).toLocaleString(DateTime.TIME_SIMPLE)}
-                    </Box>
-                    <SpeakerList speakers={speakers} />
-                </Box>
+                <TalkHeader talk={talk} speakers={speakers} />
                 <Grid container spacing={SPACING.LAYOUT}>
                     {voteItems.map((voteItem, key) => (
                         <TalkVote

--- a/src/feedback/talk/TalkHeader.js
+++ b/src/feedback/talk/TalkHeader.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import Box from '@material-ui/core/Box'
+import Title from '../layout/Title'
+import { COLORS } from '../../constants/colors'
+import { DateTime } from 'luxon'
+import SpeakerList from '../speaker/SpeakerList'
+
+const formatTalkDateTime = (talk) => {
+    const startDate = DateTime.fromISO(talk.startTime, {
+        setZone: true,
+    }).toLocaleString({
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+    })
+
+    const startTime = DateTime.fromISO(talk.startTime, { setZone: true })
+        .setZone('local', { keepLocalTime: true })
+        .toLocaleString(DateTime.TIME_SIMPLE)
+
+    const endTime = DateTime.fromISO(talk.endTime, {
+        setZone: true,
+    }).toLocaleString(DateTime.TIME_SIMPLE)
+
+    return `${startDate} / ${startTime} - ${endTime}`
+}
+
+const TalkHeader = ({ talk, speakers }) => {
+    return (
+        <Box marginBottom={4}>
+            <Title variant="h2" color="textPrimary">
+                {talk.title}
+                <Box
+                    color={COLORS.GRAY}
+                    fontSize={20}
+                    marginLeft={1}
+                    component="span">
+                    {talk.tags &&
+                        talk.tags.map((tag, key) => (
+                            <span key={key}>#{tag} </span>
+                        ))}
+                </Box>
+            </Title>
+            <Box fontSize={16} color={COLORS.GRAY} marginBottom={2}>
+                {talk.startTime && formatTalkDateTime(talk)}
+            </Box>
+            <SpeakerList speakers={speakers} />
+        </Box>
+    )
+}
+
+export default TalkHeader

--- a/src/feedback/talks/TalksDateMenu.js
+++ b/src/feedback/talks/TalksDateMenu.js
@@ -9,6 +9,8 @@ import { COLORS } from '../../constants/colors'
 import { Link } from 'react-router-dom'
 import { DateTime } from 'luxon'
 import makeStyles from '@material-ui/core/styles/makeStyles'
+import { useTranslation } from 'react-i18next'
+import { TALK_NO_DATE } from '../../core/talks/talksUtils'
 
 const useStyles = makeStyles({
     menu: {
@@ -19,19 +21,26 @@ const useStyles = makeStyles({
 })
 
 const TalksDateMenu = () => {
+    const { t } = useTranslation()
     const talksDates = useSelector(getTalksDatesSelector)
     const selectedDate = useSelector(getProjectSelectedDateSelector)
     const currentProjectId = useSelector(getProjectIdSelector)
-
     const classes = useStyles()
+
+    if (talksDates.length === 1 && talksDates.includes(TALK_NO_DATE)) {
+        return ''
+    }
 
     return (
         <div className={classes.menu}>
-            {talksDates.map(date => (
+            {talksDates.map((date) => (
                 <Item
                     key={date}
                     date={date}
-                    url={`/${currentProjectId}/${date}`}
+                    url={`/${currentProjectId}/${
+                        date === TALK_NO_DATE ? '' : date
+                    }`}
+                    noDateLabel={t('talks.menuNoDate')}
                     isSelected={selectedDate === date}
                 />
             ))}
@@ -39,13 +48,13 @@ const TalksDateMenu = () => {
     )
 }
 
-const useStylesItem = makeStyles(theme => ({
+const useStylesItem = makeStyles((theme) => ({
     item: {
-        color: props =>
+        color: (props) =>
             props.isSelected
                 ? theme.palette.text.primary
                 : theme.palette.text.secondary,
-        borderBottom: props =>
+        borderBottom: (props) =>
             props.isSelected ? `2px ${COLORS.RED_ORANGE} solid` : 'none',
         '&:hover': {
             color: COLORS.RED_ORANGE,
@@ -58,18 +67,25 @@ const useStylesItem = makeStyles(theme => ({
     },
 }))
 
-const Item = ({ date, url, isSelected }) => {
+const Item = ({ date, url, isSelected, noDateLabel }) => {
     const classes = useStylesItem({
         isSelected,
     })
 
+    const getDateLabel = (date) => {
+        if (date !== TALK_NO_DATE) {
+            return DateTime.fromISO(date).toLocaleString({
+                weekday: 'long',
+                day: 'numeric',
+            })
+        }
+        return noDateLabel
+    }
+
     return (
         <div className={classes.item}>
             <Link to={`${url}`} className={classes.a}>
-                {DateTime.fromISO(date).toLocaleString({
-                    weekday: 'long',
-                    day: 'numeric',
-                })}
+                {getDateLabel(date)}
             </Link>
         </div>
     )

--- a/src/feedback/talks/TalksListWrapper.js
+++ b/src/feedback/talks/TalksListWrapper.js
@@ -19,6 +19,7 @@ import { useParams } from 'react-router-dom'
 import SearchNoMatch from './SearchNoMatch'
 import SearchExtendedMatch from './SearchExtendedMatch'
 import { getVotesByTalkSelector } from '../vote/voteSelectors'
+import { TALK_NO_DATE } from '../../core/talks/talksUtils'
 
 const TalksListWrapper = () => {
     const dispatch = useDispatch()
@@ -37,7 +38,7 @@ const TalksListWrapper = () => {
     }, [dispatch])
 
     useEffect(() => {
-        dispatch(setSelectedDate(routerParams.date))
+        dispatch(setSelectedDate(routerParams.date || TALK_NO_DATE))
     }, [routerParams.date, dispatch])
 
     if (errorTalksLoad) {

--- a/src/feedback/translations/languages/en.feedback.json
+++ b/src/feedback/translations/languages/en.feedback.json
@@ -15,6 +15,9 @@
     "searchNoMatchAtAll": "No talk matched your criteria.",
     "searchNoMatch": "No talk matched your criteria on ",
     "searchExtendedMatch": "Talk(s) on the other day matching your search:",
+    "talks": {
+        "menuNoDate": "Without date"
+    },
     "footer": {
         "madeBy": "Powered by"
     }

--- a/src/feedback/translations/languages/fr.feedback.json
+++ b/src/feedback/translations/languages/fr.feedback.json
@@ -15,6 +15,9 @@
     "searchNoMatchAtAll": "Aucune présentation ne correspond à vos critères.",
     "searchNoMatch": "Aucune présentation ne correspond à vos critères le",
     "searchExtendedMatch": "Présentation(s) les autres jours correspondant à votre recherche:",
+    "talks": {
+        "menuNoDate": "Sans date"
+    },
     "footer": {
         "madeBy": "Propulsé par"
     }


### PR DESCRIPTION
Fix #659 

- talk dates are now optional
- Feedback: if all talks are without dates, hide the date selection on the feedback app & display them from the root (example.com/mytalk)  without the day at the end. This get one step closer to https://github.com/HugoGresse/open-feedback/issues/535
- Feedback: if one talk or more has no dates but others has, display a "Without date" in the menu, selected by default
- Admin: date time picker is now a dialog with a Clear/Cancel/OK button inside
- Admin: date time field no longer show autocomplete help

Eg event with some talks without dates
<img width="774" alt="Capture d’écran 2020-05-21 à 13 00 03" src="https://user-images.githubusercontent.com/662377/82558554-310f1000-9b6e-11ea-848f-014360345c30.png">

eg event with no date on talks
<img width="953" alt="Capture d’écran 2020-05-21 à 13 00 23" src="https://user-images.githubusercontent.com/662377/82558557-33716a00-9b6e-11ea-8c71-05e3ae21ab92.png">
