### PR TITLE
[Feedback/Admin] Redirect to the talk directely if event is showing only one talk

### DIFF
--- a/src/admin/project/settings/setup/SettingsForm.js
+++ b/src/admin/project/settings/setup/SettingsForm.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { array, object, string } from 'yup'
+import { array, bool, object, string } from 'yup'
 import { Field, Form, Formik } from 'formik'
 import OFFormControl from '../../../baseComponents/form/formControl/OFFormControl'
 import OFAutoComplete from '../../../baseComponents/form/autoComplete/OFAutoComplete'
@@ -7,18 +7,24 @@ import { useTranslation } from 'react-i18next'
 import TranslatedTypography from '../../../baseComponents/TranslatedTypography'
 import LangMap from 'langmap'
 import Grid from '@material-ui/core/Grid'
-import { useDispatch, useStore } from 'react-redux'
-import { getLanguagesSelector } from '../../core/projectSelectors'
+import { useDispatch, useSelector, useStore } from 'react-redux'
+import {
+    getLanguagesSelector,
+    getSelectedProjectSelector,
+} from '../../core/projectSelectors'
 import { CircularProgress } from '@material-ui/core'
 import FormikAutoSave from '../../../baseComponents/form/autoSave/FormikAutoSave'
 import AutoSaveNotice from '../../../baseComponents/layouts/AutoSaveNotice'
 import Box from '@material-ui/core/Box'
 import langMapArray from '../../utils/convertLangMapArray'
 import { editProject } from '../../core/actions/editProject'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import { OFSwitch } from '../../../baseComponents/form/switch/OFSwitch'
 
 const SettingsForm = () => {
     const dispatch = useDispatch()
     const { t } = useTranslation()
+    const project = useSelector(getSelectedProjectSelector)
     // Doing this prevent the selector to be connected to redux directly, thus prevent future update of initialValues
     const initialLanguages = getLanguagesSelector(useStore().getState())
 
@@ -26,12 +32,14 @@ const SettingsForm = () => {
         <Formik
             validationSchema={object().shape({
                 languages: array().of(string()),
+                disableSoloTalkRedirect: bool(),
             })}
             initialValues={{
                 languages: initialLanguages.map((tag) => ({
                     ...LangMap[tag],
                     tag,
                 })),
+                disableSoloTalkRedirect: !project.disableSoloTalkRedirect,
             }}>
             {({ values }) => (
                 <Form method="POST">
@@ -39,7 +47,7 @@ const SettingsForm = () => {
                         i18nKey="settingsSetup.settings"
                         variant="h5"
                     />
-                    <Grid container>
+                    <Grid container spacing={4}>
                         <Grid item xs={12} sm={6}>
                             <OFFormControl
                                 name={t('settingsSetup.languages')}
@@ -59,6 +67,22 @@ const SettingsForm = () => {
                                 />
                             </OFFormControl>
                         </Grid>
+                        <Grid item xs={12} sm={6}>
+                            <OFFormControl fieldName="disableSoloTalkRedirect">
+                                <FormControlLabel
+                                    label={t(
+                                        'settingsSetup.disableSoloTalkRedirect'
+                                    )}
+                                    labelPlacement="start"
+                                    control={
+                                        <Field
+                                            name="disableSoloTalkRedirect"
+                                            component={OFSwitch}
+                                        />
+                                    }
+                                />
+                            </OFFormControl>
+                        </Grid>
                     </Grid>
 
                     <FormikAutoSave
@@ -66,7 +90,13 @@ const SettingsForm = () => {
                             const languages = values.languages.map(
                                 (value) => value.tag
                             )
-                            return dispatch(editProject({ languages }))
+                            return dispatch(
+                                editProject({
+                                    ...values,
+                                    languages,
+                                    disableSoloTalkRedirect: !values.disableSoloTalkRedirect,
+                                })
+                            )
                         }}
                         render={({ isSaving, lastSavedDate, saveError }) => (
                             <div>

--- a/src/admin/translations/languages/en.admin.json
+++ b/src/admin/translations/languages/en.admin.json
@@ -181,7 +181,8 @@
             }
         },
         "settings": "Settings",
-        "languages": "Additional languages (for the voting form)"
+        "languages": "Additional languages (for the voting form)",
+        "disableSoloTalkRedirect": "Force redirect to the talk if only one talk listed"
     },
     "settingsUser": {
         "add": "Add a new member to the event",

--- a/src/admin/translations/languages/fr.admin.json
+++ b/src/admin/translations/languages/fr.admin.json
@@ -18,7 +18,7 @@
         "save": "Sauvegarder",
         "download": "Télécharger",
         "close": "Fermer",
-        "saved": "Sauvegarder",
+        "saved": "Sauvegardé",
         "preview": "Aperçu",
         "pick": "Sélectionner",
         "or": "OU",
@@ -181,7 +181,8 @@
             }
         },
         "settings": "Paramètres",
-        "languages": "Langues additionnelles (pour le bulletin de votes)"
+        "languages": "Langues additionnelles (pour le bulletin de votes)",
+        "disableSoloTalkRedirect": "Forcer la redirection à la présentation si il n'y en a qu'une listé"
     },
     "settingsUser": {
         "add": "Ajouter un nouveau membre à l'événement",

--- a/src/feedback/talks/TalksListWrapper.js
+++ b/src/feedback/talks/TalksListWrapper.js
@@ -9,28 +9,37 @@ import {
     getExtendedSearchTalksSelector,
     getTalksLoadError,
     isTalksLoadingSelector,
+    getFilteredTalksSelector,
 } from '../../core/talks/talksSelectors'
 import Error from '../../baseComponents/customComponent/Error'
 import LoaderMatchParent from '../../baseComponents/customComponent/LoaderMatchParent'
 import TalksDateMenu from './TalksDateMenu'
 import TalksList from './TalksList'
 import { getSpeakers } from '../../core/speakers/speakerActions'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import SearchNoMatch from './SearchNoMatch'
 import SearchExtendedMatch from './SearchExtendedMatch'
 import { getVotesByTalkSelector } from '../vote/voteSelectors'
 import { TALK_NO_DATE } from '../../core/talks/talksUtils'
+import {
+    getProjectSelectedDateSelector,
+    getProjectSelector,
+} from '../project/projectSelectors'
 
 const TalksListWrapper = () => {
     const dispatch = useDispatch()
     const routerParams = useParams()
+    const history = useHistory()
 
+    const project = useSelector(getProjectSelector)
     const errorTalksLoad = useSelector(getTalksLoadError)
+    const talks = useSelector(getFilteredTalksSelector)
     const currentTalksByTrack = useSelector(getCurrentTalksGroupByTrackSelector)
     const talkIsLoading = useSelector(isTalksLoadingSelector)
     const filter = useSelector(getTalksFilterSelector)
     const userTalkVote = useSelector(getVotesByTalkSelector)
     const extendedSearchTalks = useSelector(getExtendedSearchTalksSelector)
+    const selectedDate = useSelector(getProjectSelectedDateSelector)
 
     useEffect(() => {
         dispatch(getTalks())
@@ -40,6 +49,18 @@ const TalksListWrapper = () => {
     useEffect(() => {
         dispatch(setSelectedDate(routerParams.date || TALK_NO_DATE))
     }, [routerParams.date, dispatch])
+
+    useEffect(() => {
+        if (
+            talks &&
+            talks.length === 1 &&
+            project &&
+            !project.disableSoloTalkRedirect &&
+            selectedDate
+        ) {
+            history.push(`/${project.id}/${selectedDate}/${talks[0].id}`)
+        }
+    }, [talks, project, history, selectedDate])
 
     if (errorTalksLoad) {
         return (

--- a/src/feedback/talks/TalksListWrapper.js
+++ b/src/feedback/talks/TalksListWrapper.js
@@ -9,7 +9,7 @@ import {
     getExtendedSearchTalksSelector,
     getTalksLoadError,
     isTalksLoadingSelector,
-    getFilteredTalksSelector,
+    getTalksAsArraySelector,
 } from '../../core/talks/talksSelectors'
 import Error from '../../baseComponents/customComponent/Error'
 import LoaderMatchParent from '../../baseComponents/customComponent/LoaderMatchParent'
@@ -33,7 +33,7 @@ const TalksListWrapper = () => {
 
     const project = useSelector(getProjectSelector)
     const errorTalksLoad = useSelector(getTalksLoadError)
-    const talks = useSelector(getFilteredTalksSelector)
+    const talks = useSelector(getTalksAsArraySelector)
     const currentTalksByTrack = useSelector(getCurrentTalksGroupByTrackSelector)
     const talkIsLoading = useSelector(isTalksLoadingSelector)
     const filter = useSelector(getTalksFilterSelector)

--- a/src/feedback/talks/TalksListWrapper.js
+++ b/src/feedback/talks/TalksListWrapper.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { getTalks } from '../../core/talks/talksActions'
-import { setSelectedDate } from './../project/projectActions'
+import { setSelectedDate } from '../project/projectActions'
 
 import {
     getCurrentTalksGroupByTrackSelector,


### PR DESCRIPTION
Fix #613 

Redirect to the talk if only one talk is listed, on by default for all existing and new events. 
Add a new settings in the admin to disable this. 