### PR TITLE
[Admin & feedback] New option to hide event name in Feedback header

### DIFF
--- a/src/admin/baseComponents/form/formControl/OFFormControl.js
+++ b/src/admin/baseComponents/form/formControl/OFFormControl.js
@@ -5,10 +5,10 @@ import makeStyles from '@material-ui/core/styles/makeStyles'
 import { ErrorMessage, useField } from 'formik'
 import { Typography } from '@material-ui/core'
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
     formControl: {
         width: '100%',
-        marginTop: theme.spacing(3),
+        marginTop: (props) => !props.noTopMargin && theme.spacing(3),
     },
     label: {
         fontSize: theme.typography.fontSize * 1.2,
@@ -25,10 +25,12 @@ const OFFormControl = ({
     fieldName,
     displayErrorMessageDirectly,
     children,
+    noTopMargin,
 }) => {
-    const classes = useStyles()
-    // eslint-disable-next-line no-unused-vars
-    const [field, meta, helpers] = useField(fieldName)
+    const classes = useStyles({
+        noTopMargin,
+    })
+    const [, meta] = useField(fieldName)
 
     return (
         <FormControl className={classes.formControl}>
@@ -44,7 +46,7 @@ const OFFormControl = ({
             {!displayErrorMessageDirectly && (
                 <ErrorMessage
                     name={fieldName}
-                    render={msg => (
+                    render={(msg) => (
                         <Typography className={classes.errorMessage}>
                             {msg}
                         </Typography>

--- a/src/admin/baseComponents/form/switch/OFSwitch.js
+++ b/src/admin/baseComponents/form/switch/OFSwitch.js
@@ -9,6 +9,7 @@ const fieldToSwitch = ({
 }) => {
     return {
         disabled: disabled !== undefined ? disabled : isSubmitting,
+        color: 'primary',
         ...props,
         ...field,
         value: Boolean(field.name),
@@ -16,4 +17,4 @@ const fieldToSwitch = ({
     }
 }
 
-export const OFSwitch = props => <MuiSwitch {...fieldToSwitch(props)} />
+export const OFSwitch = (props) => <MuiSwitch {...fieldToSwitch(props)} />

--- a/src/admin/project/settings/event/ProjectSettingsForm.js
+++ b/src/admin/project/settings/event/ProjectSettingsForm.js
@@ -25,6 +25,9 @@ const useStyles = makeStyles((theme) => ({
     chipLabel: {
         marginTop: theme.spacing(3),
     },
+    reducedLabelFontSize: {
+        fontSize: theme.typography.fontSize * 0.9,
+    },
 }))
 
 const ProjectSettingsForm = ({ project }) => {
@@ -42,6 +45,7 @@ const ProjectSettingsForm = ({ project }) => {
         restrictVoteRange: !!project.voteStartTime,
         voteStartTime: project.voteStartTime || DateTime.local().toISO(),
         voteEndTime: project.voteEndTime || DateTime.local().toISO(),
+        hideEventName: project.hideEventName || false,
     }
 
     return (
@@ -60,6 +64,7 @@ const ProjectSettingsForm = ({ project }) => {
                 restrictVoteRange: boolean(),
                 voteStartTime: string(),
                 voteEndTime: string(),
+                hideEventName: boolean().required(),
             })}
             initialValues={initialValues}
             onSubmit={(values) =>
@@ -77,6 +82,7 @@ const ProjectSettingsForm = ({ project }) => {
                         voteEndTime: DateTime.fromISO(
                             values.voteEndTime
                         ).toISO(),
+                        hideEventName: values.hideEventName,
                     })
                 )
             }>
@@ -91,6 +97,22 @@ const ProjectSettingsForm = ({ project }) => {
                                 type="text"
                                 isSubmitting={isSubmitting}
                             />
+                            <OFFormControl
+                                fieldName="hideEventName"
+                                noTopMargin>
+                                <FormControlLabel
+                                    label={t('settingsEvent.hideEventName')}
+                                    classes={{
+                                        label: classes.reducedLabelFontSize,
+                                    }}
+                                    control={
+                                        <Field
+                                            name="hideEventName"
+                                            component={OFSwitch}
+                                        />
+                                    }
+                                />
+                            </OFFormControl>
 
                             <OFFormControlInputFormiked
                                 name={t('settingsEvent.fieldSchedule')}

--- a/src/admin/translations/languages/en.admin.json
+++ b/src/admin/translations/languages/en.admin.json
@@ -150,7 +150,8 @@
         "fieldVoteOpen": "Vote open time (in your local timezone)",
         "fieldVoteRange": "Restrict voting open/close date",
         "pick": "Pick",
-        "save": "Save"
+        "save": "Save",
+        "hideEventName": "Do not display the event name in the feedback, only the logo"
     },
     "settingsSetup": {
         "cannotChange": "You cannot change the setup mode after creating the event.",

--- a/src/admin/translations/languages/fr.admin.json
+++ b/src/admin/translations/languages/fr.admin.json
@@ -150,7 +150,8 @@
         "fieldVoteOpen": "Heure du début des votes (dans votre fuseau horaire)",
         "fieldVoteRange": "Restreindre la date de début/fin des votes",
         "pick": "Choisir",
-        "save": "Sauvegarder"
+        "save": "Sauvegarder",
+        "hideEventName": "Ne pas afficher le nom de l'évènement dans les feedbacks (uniquement le logo)"
     },
     "settingsSetup": {
         "cannotChange": "Vous ne pouvez pas changer le mode de configuration après avoir créé l'évènement.",

--- a/src/feedback/layout/Header.js
+++ b/src/feedback/layout/Header.js
@@ -93,7 +93,7 @@ const Header = ({ project }) => {
                     />
                     <Hidden smDown>
                         <Title component="h1" color="textPrimary">
-                            {project.name}
+                            {!project.hideEventName && project.name}
                         </Title>
                     </Hidden>
                 </div>

--- a/src/feedback/talks/TalksListWrapper.js
+++ b/src/feedback/talks/TalksListWrapper.js
@@ -61,7 +61,7 @@ const TalksListWrapper = () => {
         ) {
             history.push(`/${project.id}/${selectedDate}/${talks[0].id}`)
         }
-    }, [talks, project, history, selectedDate])
+    }, [talks, project, history, selectedDate, talkIsLoading])
 
     if (errorTalksLoad) {
         return (

--- a/src/feedback/talks/TalksListWrapper.js
+++ b/src/feedback/talks/TalksListWrapper.js
@@ -54,6 +54,7 @@ const TalksListWrapper = () => {
         if (
             talks &&
             talks.length === 1 &&
+            !talkIsLoading &&
             project &&
             !project.disableSoloTalkRedirect &&
             selectedDate


### PR DESCRIPTION
Fix #667 

[Admin & Feedback] New option to hide event name in feedback app, that will only display the logo
Fix a bug on a PR made this week for redirect on solo talk. If one talk was opened and back arrow pressed, the other where not loaded yet to it will redirect to the selected talk rather than the talk list. 