### PR TITLE
[Feedback] Prevent date selection buttons overflow and wrap them (responsive)

### DIFF
--- a/src/feedback/talks/TalkDateMenuItem.js
+++ b/src/feedback/talks/TalkDateMenuItem.js
@@ -1,0 +1,58 @@
+import makeStyles from '@material-ui/core/styles/makeStyles'
+import { COLORS } from '../../constants/colors'
+import { useTranslation } from 'react-i18next'
+import { TALK_NO_DATE } from '../../core/talks/talksUtils'
+import { DateTime } from 'luxon'
+import { Link } from 'react-router-dom'
+import React from 'react'
+
+const useStyles = makeStyles((theme) => ({
+    item: {
+        color: (props) =>
+            props.isSelected
+                ? theme.palette.text.primary
+                : theme.palette.text.secondary,
+        borderBottom: (props) =>
+            props.isSelected ? `2px ${COLORS.RED_ORANGE} solid` : 'none',
+        '&:hover': {
+            color: COLORS.RED_ORANGE,
+        },
+    },
+    a: {
+        padding: 10,
+        color: 'inherit',
+        display: 'block',
+    },
+}))
+
+const DATE_FORMAT = {
+    weekday: 'long',
+    day: 'numeric',
+}
+
+export const TalkDateMenuItem = ({ date, url, isSelected, noDateLabel }) => {
+    const { t } = useTranslation()
+    const classes = useStyles({
+        isSelected,
+    })
+
+    const getDateLabel = (date) => {
+        if (date !== TALK_NO_DATE) {
+            return DateTime.fromISO(date).toLocaleString(DATE_FORMAT)
+        }
+        return noDateLabel
+    }
+
+    const label = getDateLabel(date)
+
+    return (
+        <div className={classes.item}>
+            <Link
+                to={`${url}`}
+                className={classes.a}
+                title={t('talks.date') + label}>
+                {label}
+            </Link>
+        </div>
+    )
+}

--- a/src/feedback/talks/TalkDateMenuItem.js
+++ b/src/feedback/talks/TalkDateMenuItem.js
@@ -5,15 +5,21 @@ import { TALK_NO_DATE } from '../../core/talks/talksUtils'
 import { DateTime } from 'luxon'
 import { Link } from 'react-router-dom'
 import React from 'react'
+import Typography from '@material-ui/core/Typography'
 
 const useStyles = makeStyles((theme) => ({
     item: {
+        transition: 'all 120ms ease-in-out',
         color: (props) =>
             props.isSelected
                 ? theme.palette.text.primary
                 : theme.palette.text.secondary,
         borderBottom: (props) =>
-            props.isSelected ? `2px ${COLORS.RED_ORANGE} solid` : 'none',
+            `2px ${
+                props.isSelected
+                    ? COLORS.RED_ORANGE
+                    : theme.palette.pageBackground
+            } solid`,
         '&:hover': {
             color: COLORS.RED_ORANGE,
         },
@@ -22,6 +28,11 @@ const useStyles = makeStyles((theme) => ({
         padding: 10,
         color: 'inherit',
         display: 'block',
+    },
+    blank: {
+        padding: 10,
+        fontSize: 25,
+        lineHeight: '0.6em',
     },
 }))
 
@@ -55,4 +66,10 @@ export const TalkDateMenuItem = ({ date, url, isSelected, noDateLabel }) => {
             </Link>
         </div>
     )
+}
+
+export const TalkDateMenuItemBlank = ({ children }) => {
+    const classes = useStyles()
+
+    return <Typography className={classes.blank}>{children}</Typography>
 }

--- a/src/feedback/talks/TalksDateMenu.js
+++ b/src/feedback/talks/TalksDateMenu.js
@@ -41,7 +41,7 @@ const TalksDateMenu = () => {
     return (
         <>
             <ul className={classes.menu}>
-                {items.map(({ page, type, selected, ...item }, index) => {
+                {items.map(({ page, type, selected }, index) => {
                     let children = null
                     const pageFixed = page - 1
 

--- a/src/feedback/talks/TalksDateMenu.js
+++ b/src/feedback/talks/TalksDateMenu.js
@@ -5,12 +5,10 @@ import {
     getProjectIdSelector,
     getProjectSelectedDateSelector,
 } from '../project/projectSelectors'
-import { COLORS } from '../../constants/colors'
-import { Link } from 'react-router-dom'
-import { DateTime } from 'luxon'
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import { useTranslation } from 'react-i18next'
 import { TALK_NO_DATE } from '../../core/talks/talksUtils'
+import { TalkDateMenuItem } from './TalkDateMenuItem'
 
 const useStyles = makeStyles({
     menu: {
@@ -34,7 +32,7 @@ const TalksDateMenu = () => {
     return (
         <div className={classes.menu}>
             {talksDates.map((date) => (
-                <Item
+                <TalkDateMenuItem
                     key={date}
                     date={date}
                     url={`/${currentProjectId}/${
@@ -44,55 +42,6 @@ const TalksDateMenu = () => {
                     isSelected={selectedDate === date}
                 />
             ))}
-        </div>
-    )
-}
-
-const useStylesItem = makeStyles((theme) => ({
-    item: {
-        color: (props) =>
-            props.isSelected
-                ? theme.palette.text.primary
-                : theme.palette.text.secondary,
-        borderBottom: (props) =>
-            props.isSelected ? `2px ${COLORS.RED_ORANGE} solid` : 'none',
-        '&:hover': {
-            color: COLORS.RED_ORANGE,
-        },
-    },
-    a: {
-        padding: 10,
-        color: 'inherit',
-        display: 'block',
-    },
-}))
-
-const Item = ({ date, url, isSelected, noDateLabel }) => {
-    const { t } = useTranslation()
-    const classes = useStylesItem({
-        isSelected,
-    })
-
-    const getDateLabel = (date) => {
-        if (date !== TALK_NO_DATE) {
-            return DateTime.fromISO(date).toLocaleString({
-                weekday: 'long',
-                day: 'numeric',
-            })
-        }
-        return noDateLabel
-    }
-
-    const label = getDateLabel(date)
-
-    return (
-        <div className={classes.item}>
-            <Link
-                to={`${url}`}
-                className={classes.a}
-                title={t('talks.date') + label}>
-                {label}
-            </Link>
         </div>
     )
 }

--- a/src/feedback/talks/TalksDateMenu.js
+++ b/src/feedback/talks/TalksDateMenu.js
@@ -8,11 +8,13 @@ import {
 import makeStyles from '@material-ui/core/styles/makeStyles'
 import { useTranslation } from 'react-i18next'
 import { TALK_NO_DATE } from '../../core/talks/talksUtils'
-import { TalkDateMenuItem } from './TalkDateMenuItem'
+import { TalkDateMenuItem, TalkDateMenuItemBlank } from './TalkDateMenuItem'
+import { usePagination } from '@material-ui/lab'
 
 const useStyles = makeStyles({
     menu: {
         display: 'flex',
+        flexWrap: 'wrap',
         justifyContent: 'center',
         marginBottom: 16,
     },
@@ -23,6 +25,13 @@ const TalksDateMenu = () => {
     const talksDates = useSelector(getTalksDatesSelector)
     const selectedDate = useSelector(getProjectSelectedDateSelector)
     const currentProjectId = useSelector(getProjectIdSelector)
+    const { items } = usePagination({
+        count: talksDates.length,
+        page: talksDates.indexOf(selectedDate) + 1,
+        boundaryCount: 2,
+        hideNextButton: true,
+        hidePrevButton: true,
+    })
     const classes = useStyles()
 
     if (talksDates.length === 1 && talksDates.includes(TALK_NO_DATE)) {
@@ -30,19 +39,37 @@ const TalksDateMenu = () => {
     }
 
     return (
-        <div className={classes.menu}>
-            {talksDates.map((date) => (
-                <TalkDateMenuItem
-                    key={date}
-                    date={date}
-                    url={`/${currentProjectId}/${
-                        date === TALK_NO_DATE ? '' : date
-                    }`}
-                    noDateLabel={t('talks.menuNoDate')}
-                    isSelected={selectedDate === date}
-                />
-            ))}
-        </div>
+        <>
+            <ul className={classes.menu}>
+                {items.map(({ page, type, selected, ...item }, index) => {
+                    let children = null
+                    const pageFixed = page - 1
+
+                    if (type === 'start-ellipsis' || type === 'end-ellipsis') {
+                        children = (
+                            <TalkDateMenuItemBlank key="..." isSelected={false}>
+                                …
+                            </TalkDateMenuItemBlank>
+                        )
+                    } else if (type === 'page') {
+                        const date = talksDates[pageFixed]
+                        children = (
+                            <TalkDateMenuItem
+                                key={date}
+                                date={date}
+                                url={`/${currentProjectId}/${
+                                    date === TALK_NO_DATE ? '' : date
+                                }`}
+                                noDateLabel={t('talks.menuNoDate')}
+                                isSelected={selected}
+                            />
+                        )
+                    }
+
+                    return <li key={index}>{children}</li>
+                })}
+            </ul>
+        </>
     )
 }
 


### PR DESCRIPTION
Use a pagination on dates, which make all the date not visible directly but also prevent displaying an infinite number of them. The current behavior is having 8 dates displayed at the same time (two at the begining and at the end, some in the midle)
It also wrap so date can go to the next line on smaller screens. And also add small animation on overflow and selection.
Close #614 

Some example: 
![Capture d’écran 2021-03-28 à 15 53 52](https://user-images.githubusercontent.com/662377/112754762-d213f600-8fdd-11eb-98a0-453f55858f8d.png)

![Capture d’écran 2021-03-28 à 15 53 45](https://user-images.githubusercontent.com/662377/112754763-d3ddb980-8fdd-11eb-9a83-3580e1b62b5a.png)
