### PR TITLE
[Feedback] New queryParams to hide feedback header

### DIFF
--- a/src/feedback/AppLayout.js
+++ b/src/feedback/AppLayout.js
@@ -1,6 +1,4 @@
 import React, { useEffect } from 'react'
-
-import Header from './layout/Header'
 import '../App.css'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory, useParams } from 'react-router-dom'
@@ -23,6 +21,7 @@ import { signIn } from './auth/authActions'
 import { getVotes } from './vote/voteActions'
 import { useTranslation } from 'react-i18next'
 import { TALK_NO_DATE } from '../core/talks/talksUtils'
+import { Header } from './layout/Header'
 
 const useStyles = makeStyles((theme) => ({
     container: {

--- a/src/feedback/layout/Header.js
+++ b/src/feedback/layout/Header.js
@@ -10,6 +10,7 @@ import { darken } from '@material-ui/core/styles'
 import { useTranslation } from 'react-i18next'
 import { Typography } from '@material-ui/core'
 import { isInIFrame } from '../utils/isInIFrame'
+import useQuery from '../../utils/useQuery'
 
 const useStyles = makeStyles((theme) => ({
     logo: {
@@ -74,12 +75,17 @@ const useStyles = makeStyles((theme) => ({
     },
 }))
 
-const Header = ({ project }) => {
+export const Header = ({ project }) => {
     const classes = useStyles({
         inIFrame: isInIFrame(),
     })
     const { t } = useTranslation()
     const matchParams = useParams()
+    const hideHeader = useQuery().get('hideHeader')
+
+    if (hideHeader && hideHeader === 'true') {
+        return null
+    }
 
     return (
         <header className={classes.container}>
@@ -88,7 +94,8 @@ const Header = ({ project }) => {
                     {matchParams.talkId && (
                         <Link
                             title={t('talks.list')}
-                            to={`/${matchParams.projectId}/${matchParams.date}`}>
+                            to={`/${matchParams.projectId}/${matchParams.date}`}
+                        >
                             <ArrowBack color="primary" />
                         </Link>
                     )}
@@ -99,7 +106,8 @@ const Header = ({ project }) => {
                             href={project.scheduleLink}
                             target="_blank"
                             title={`${project.name} website`}
-                            rel="noopener noreferrer">
+                            rel="noopener noreferrer"
+                        >
                             <CalendarToday />
                         </a>
                     </div>
@@ -114,7 +122,8 @@ const Header = ({ project }) => {
                         <Typography
                             variant="h1"
                             color="textPrimary"
-                            aria-label={project.hideEventName && project.name}>
+                            aria-label={project.hideEventName && project.name}
+                        >
                             {!project.hideEventName && project.name}
                         </Typography>
                     </Hidden>
@@ -124,5 +133,3 @@ const Header = ({ project }) => {
         </header>
     )
 }
-
-export default Header

--- a/src/feedback/talk/TalkHeader.js
+++ b/src/feedback/talk/TalkHeader.js
@@ -5,6 +5,7 @@ import SpeakerList from '../speaker/SpeakerList'
 import { useTheme } from '@material-ui/core'
 import Typography from '@material-ui/core/Typography'
 import makeStyles from '@material-ui/core/styles/makeStyles'
+import useQuery from '../../utils/useQuery'
 
 const formatTalkDateTime = (talk) => {
     const startDate = DateTime.fromISO(talk.startTime, {
@@ -35,19 +36,26 @@ const useStyles = makeStyles(() => ({
 const TalkHeader = ({ talk, speakers }) => {
     const classes = useStyles()
     const theme = useTheme()
+    const hideHeader = useQuery().get('hideHeader')
+
+    if (hideHeader && hideHeader === 'true') {
+        return <Box height={2}></Box>
+    }
 
     return (
         <Box marginBottom={4}>
             <Typography
                 variant="h2"
                 color="textPrimary"
-                className={classes.title}>
+                className={classes.title}
+            >
                 {talk.title}
                 <Box
                     color={theme.palette.textDimmed}
                     fontSize={20}
                     marginLeft={1}
-                    component="span">
+                    component="span"
+                >
                     {talk.tags &&
                         talk.tags.map((tag, key) => (
                             <span key={key}>#{tag} </span>
@@ -57,7 +65,8 @@ const TalkHeader = ({ talk, speakers }) => {
             <Box
                 fontSize={16}
                 color={theme.palette.textDimmed}
-                marginBottom={2}>
+                marginBottom={2}
+            >
                 {talk.startTime && formatTalkDateTime(talk)}
             </Box>
             <SpeakerList speakers={speakers} />


### PR DESCRIPTION
Close #1398 

Support a query parameters named `hideHeader=true` which hide the header of the talk and the talk & speakers of the viewed talk. 
This is done to better support the iframe if needed. 