### PR TITLE
Fix image upload: replace imagemin version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,7 @@
 *.DS_Store
 *.log
 *.iml
-.env.production.local
-.env.development.local
-.env.test.local
+.env.*.local
 .env.local
 
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1856,11 +1856,6 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "@tokenizer/token": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-        },
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -1947,6 +1942,15 @@
                 "@types/node": "*",
                 "@types/qs": "*",
                 "@types/range-parser": "*"
+            }
+        },
+        "@types/glob": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
             }
         },
         "@types/graceful-fs": {
@@ -2149,6 +2153,11 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
             "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+        },
+        "@types/minimatch": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
         },
         "@types/node": {
             "version": "8.10.58",
@@ -2705,9 +2714,9 @@
             }
         },
         "array-union": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-            "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
         },
         "array-unique": {
             "version": "0.3.2",
@@ -5358,9 +5367,9 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-glob": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -5370,18 +5379,18 @@
             },
             "dependencies": {
                 "micromatch": {
-                    "version": "4.0.4",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-                    "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+                    "version": "4.0.5",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+                    "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
                     "requires": {
-                        "braces": "^3.0.1",
-                        "picomatch": "^2.2.3"
+                        "braces": "^3.0.2",
+                        "picomatch": "^2.3.1"
                     }
                 },
                 "picomatch": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-                    "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+                    "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
                 }
             }
         },
@@ -5444,14 +5453,9 @@
             }
         },
         "file-type": {
-            "version": "16.5.3",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
-            "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
-            "requires": {
-                "readable-web-to-node-stream": "^3.0.0",
-                "strtok3": "^6.2.4",
-                "token-types": "^4.1.1"
-            }
+            "version": "12.4.2",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.2.tgz",
+            "integrity": "sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg=="
         },
         "filename-reserved-regex": {
             "version": "2.0.0",
@@ -16202,23 +16206,18 @@
             "dev": true
         },
         "globby": {
-            "version": "12.0.2",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-12.0.2.tgz",
-            "integrity": "sha512-lAsmb/5Lww4r7MM9nCCliDZVIKbZTavrsunAsHLr9oHthrZP1qi7/gAnHOsUs9bLvEt2vKVJhHmxuL7QbDuPdQ==",
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+            "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
             "requires": {
-                "array-union": "^3.0.1",
+                "@types/glob": "^7.1.1",
+                "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.7",
-                "ignore": "^5.1.8",
-                "merge2": "^1.4.1",
-                "slash": "^4.0.0"
-            },
-            "dependencies": {
-                "slash": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-                    "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
-                }
+                "fast-glob": "^3.0.3",
+                "glob": "^7.1.3",
+                "ignore": "^5.1.1",
+                "merge2": "^1.2.3",
+                "slash": "^3.0.0"
             }
         },
         "google-auth-library": {
@@ -16550,24 +16549,17 @@
             "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ=="
         },
         "imagemin": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-8.0.1.tgz",
-            "integrity": "sha512-Q/QaPi+5HuwbZNtQRqUVk6hKacI6z9iWiCSQBisAv7uBynZwO7t1svkryKl7+iSQbkU/6t9DWnHz04cFs2WY7w==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-7.0.1.tgz",
+            "integrity": "sha512-33AmZ+xjZhg2JMCe+vDf6a9mzWukE7l+wAtesjE7KyteqqKjzxv7aVQeWnul1Ve26mWvEQqyPwl0OctNBfSR9w==",
             "requires": {
-                "file-type": "^16.5.3",
-                "globby": "^12.0.0",
-                "graceful-fs": "^4.2.8",
+                "file-type": "^12.0.0",
+                "globby": "^10.0.0",
+                "graceful-fs": "^4.2.2",
                 "junk": "^3.1.0",
-                "p-pipe": "^4.0.0",
-                "replace-ext": "^2.0.0",
-                "slash": "^3.0.0"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.2.8",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-                    "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
-                }
+                "make-dir": "^3.0.0",
+                "p-pipe": "^3.0.0",
+                "replace-ext": "^1.0.0"
             }
         },
         "imagemin-jpegtran": {
@@ -19520,9 +19512,9 @@
             }
         },
         "p-pipe": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-4.0.0.tgz",
-            "integrity": "sha512-HkPfFklpZQPUKBFXzKFB6ihLriIHxnmuQdK9WmLDwe4hf2PdhhfWT/FJa+pc3bA1ywvKXtedxIRmd4Y7BTXE4w=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-3.1.0.tgz",
+            "integrity": "sha512-08pj8ATpzMR0Y80x50yJHn37NF6vjrqHutASaX5LiH5npS9XPvrUmscd9MF5R4fuYRHOxQR1FfMIlF7AzwoPqw=="
         },
         "p-reduce": {
             "version": "1.0.0",
@@ -19599,11 +19591,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-        },
-        "peek-readable": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.0.1.tgz",
-            "integrity": "sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ=="
         },
         "pend": {
             "version": "1.2.0",
@@ -19993,14 +19980,6 @@
                 "util-deprecate": "^1.0.1"
             }
         },
-        "readable-web-to-node-stream": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-            "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-            "requires": {
-                "readable-stream": "^3.6.0"
-            }
-        },
         "redent": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -20064,9 +20043,9 @@
             }
         },
         "replace-ext": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
-            "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug=="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+            "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw=="
         },
         "require-directory": {
             "version": "2.1.1",
@@ -21056,15 +21035,6 @@
                 "escape-string-regexp": "^1.0.2"
             }
         },
-        "strtok3": {
-            "version": "6.2.4",
-            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.2.4.tgz",
-            "integrity": "sha512-GO8IcFF9GmFDvqduIspUBwCzCbqzegyVKIsSymcMgiZKeCfrN9SowtUoi8+b59WZMAjIzVZic/Ft97+pynR3Iw==",
-            "requires": {
-                "@tokenizer/token": "^0.3.0",
-                "peek-readable": "^4.0.1"
-            }
-        },
         "stubs": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -21285,22 +21255,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-        },
-        "token-types": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
-            "integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
-            "requires": {
-                "@tokenizer/token": "^0.3.0",
-                "ieee754": "^1.2.1"
-            },
-            "dependencies": {
-                "ieee754": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-                }
-            }
         },
         "tr46": {
             "version": "2.0.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,7 +25,7 @@
         "firebase-functions-test": "^2.0.2",
         "firebase-tools": "^10.9.2",
         "form-data": "^3.0.1",
-        "imagemin": "8.0.1",
+        "imagemin": "7.0.1",
         "imagemin-jpegtran": "^7.0.0",
         "imagemin-pngquant": "^9.0.2",
         "lodash": "^4.17.21",


### PR DESCRIPTION
Error on resizeAndMoveImage.ts: 

```
Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /workspace/node_modules/imagemin/index.js 
```

Issue: https://github.com/imagemin/imagemin/issues/392 

Patch: rollback imagemin to 7.0.1
Long term: remove imagemin, maybe reduce image size on the client which will reduce the function size and speed up the process. 
