### PR TITLE
Fix text vote aggregation + deleting a text vote from the UI 

### DIFF
--- a/functions/src/triggers/models/vote.ts
+++ b/functions/src/triggers/models/vote.ts
@@ -81,7 +81,10 @@ export class Vote {
         aggregatedVote?: AggregatedVote
     ): VoteItemAggregationChange {
         if (this.isTextPlusVote()) {
-            if (!this.voteData.voteId) {
+            if (
+                !this.voteData.voteId ||
+                this.isTextVoteDeleted(aggregatedVote)
+            ) {
                 return {}
             }
             return {
@@ -144,6 +147,20 @@ export class Vote {
                 this.getIncrementValue()
             ),
         }
+    }
+
+    private isTextVoteDeleted(aggregatedVote?: AggregatedVote): boolean {
+        // When deleting a text vote, the vote will be an empty object {}, and if the user did not have the latest version, he will upvote a textVote which does not exist, just an empty object.
+        return (
+            !this.voteData ||
+            !aggregatedVote ||
+            !aggregatedVote[this.voteData.voteItemId] ||
+            !this.voteData.voteId ||
+            !aggregatedVote[this.voteData.voteItemId][this.voteData.voteId] ||
+            Object.keys(
+                aggregatedVote[this.voteData.voteItemId][this.voteData.voteId]
+            ).length === 0
+        )
     }
 }
 

--- a/src/feedback/talk/Talk.js
+++ b/src/feedback/talk/Talk.js
@@ -28,7 +28,7 @@ import {
 } from '../vote/voteSelectors'
 
 import Grid from '@material-ui/core/Grid'
-import TalkVote from './TalkVote'
+import { TalkVote } from './TalkVote'
 import LoaderMatchParent from '../../baseComponents/customComponent/LoaderMatchParent'
 import Error from '../../baseComponents/customComponent/Error'
 import Snackbar from '../../baseComponents/customComponent/Snackbar'

--- a/src/feedback/talk/TalkVote.js
+++ b/src/feedback/talk/TalkVote.js
@@ -1,54 +1,38 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+import React from 'react'
 import TalkVoteBoolean from './boolean/TalkVoteBoolean'
 import { TalkVoteText } from './text/TalkVoteText'
 import { VOTE_TYPE_BOOLEAN, VOTE_TYPE_TEXT } from '../../core/contants'
 
-class TalkItemVote extends Component {
-    render() {
-        const {
-            voteItem,
-            userVotes,
-            voteResult,
-            chipColors,
-            onVoteChange,
-        } = this.props
-
-        switch (voteItem.type) {
-            default:
-            case VOTE_TYPE_BOOLEAN:
-                return (
-                    <TalkVoteBoolean
-                        onVoteChange={(voteItem) => {
-                            onVoteChange(
-                                voteItem,
-                                null,
-                                userVotes && userVotes[0]
-                            )
-                        }}
-                        voteItem={voteItem}
-                        isSelected={!!userVotes}
-                        voteResult={voteResult}
-                        chipColors={chipColors}
-                    />
-                )
-            case VOTE_TYPE_TEXT:
-                return (
-                    <TalkVoteText
-                        onVoteChange={onVoteChange}
-                        voteItem={voteItem}
-                        currentUserVotes={userVotes}
-                        voteResult={voteResult}
-                        chipColors={chipColors}
-                    />
-                )
-        }
+export const TalkVote = ({
+    voteItem,
+    userVotes,
+    voteResult,
+    chipColors,
+    onVoteChange,
+}) => {
+    switch (voteItem.type) {
+        default:
+        case VOTE_TYPE_BOOLEAN:
+            return (
+                <TalkVoteBoolean
+                    onVoteChange={(voteItem) => {
+                        onVoteChange(voteItem, null, userVotes && userVotes[0])
+                    }}
+                    voteItem={voteItem}
+                    isSelected={!!userVotes}
+                    voteResult={voteResult}
+                    chipColors={chipColors}
+                />
+            )
+        case VOTE_TYPE_TEXT:
+            return (
+                <TalkVoteText
+                    onVoteChange={onVoteChange}
+                    voteItem={voteItem}
+                    currentUserVotes={userVotes}
+                    voteResult={voteResult}
+                    chipColors={chipColors}
+                />
+            )
     }
 }
-
-TalkItemVote.propTypes = {
-    voteItem: PropTypes.object.isRequired,
-    chipColors: PropTypes.array,
-}
-
-export default TalkItemVote

--- a/src/feedback/talk/text/TalkVoteText.js
+++ b/src/feedback/talk/text/TalkVoteText.js
@@ -81,7 +81,7 @@ export const TalkVoteText = ({
         dataLoaded: false,
     })
 
-    const getVoteFromCurrentVotes = () => {
+    useEffect(() => {
         if (currentUserVotes && (!data.dataLoaded || !data.vote)) {
             const foundTextVote = currentUserVotes.find(
                 (vote) => !!vote.text && vote.voteType !== VOTE_TYPE_TEXT_PLUS
@@ -95,11 +95,7 @@ export const TalkVoteText = ({
                 })
             }
         }
-    }
-
-    useEffect(() => {
-        getVoteFromCurrentVotes()
-    }, [currentUserVotes, data.dataLoaded, getVoteFromCurrentVotes])
+    }, [currentUserVotes, data.dataLoaded])
 
     const onTextChange = (event) => {
         setData({

--- a/src/feedback/talk/text/TalkVoteText.js
+++ b/src/feedback/talk/text/TalkVoteText.js
@@ -95,7 +95,7 @@ export const TalkVoteText = ({
                 })
             }
         }
-    }, [currentUserVotes, data.dataLoaded])
+    }, [currentUserVotes, data.vote, data.dataLoaded])
 
     const onTextChange = (event) => {
         setData({

--- a/src/feedback/talk/text/TalkVoteText.js
+++ b/src/feedback/talk/text/TalkVoteText.js
@@ -81,8 +81,8 @@ export const TalkVoteText = ({
         dataLoaded: false,
     })
 
-    useEffect(() => {
-        if (currentUserVotes && !data.dataLoaded) {
+    const getVoteFromCurrentVotes = () => {
+        if (currentUserVotes && (!data.dataLoaded || !data.vote)) {
             const foundTextVote = currentUserVotes.find(
                 (vote) => !!vote.text && vote.voteType !== VOTE_TYPE_TEXT_PLUS
             )
@@ -95,7 +95,11 @@ export const TalkVoteText = ({
                 })
             }
         }
-    }, [currentUserVotes, data.dataLoaded])
+    }
+
+    useEffect(() => {
+        getVoteFromCurrentVotes()
+    }, [currentUserVotes, data.dataLoaded, getVoteFromCurrentVotes])
 
     const onTextChange = (event) => {
         setData({
@@ -105,14 +109,15 @@ export const TalkVoteText = ({
     }
 
     const onVoteDelete = () => {
-        onVoteChange(voteItem, null, data.vote)
-
         setData({
             ...data,
             comment: '',
             status: null,
             vote: null,
         })
+        if (data.vote) {
+            onVoteChange(voteItem, null, data.vote)
+        }
     }
 
     const saveUpdateKey =


### PR DESCRIPTION
- Fix #1477 : a user upvote an already deleted Text vote. In this case, the DB object was `{}` so it's content became `{ plus: 1}` which is incorect
- Fix deleting a text vote after adding it after deleting it