### PR TITLE
Fix minor typo in error message when usin JSON link for configuration

### DIFF
--- a/src/admin/project/setupTypeForms/validation/validationString.jsx
+++ b/src/admin/project/setupTypeForms/validation/validationString.jsx
@@ -30,7 +30,7 @@ const validationText = {
             connecting: 'We are fetching your json.',
             connected: 'We received your data.',
             error:
-                'We failed to get your data, they server may be offline, or the url may be wrong.',
+                'We failed to get your data, the server may be offline, or the url may be wrong.',
         },
         [PROJECT_TYPE_HOVERBOARDV2]: {
             connecting: 'We are connecting to your Firestore database.',


### PR DESCRIPTION
Self-explanatory :slightly_smiling_face: 

_Note: let me know if there's anything I should change, I tried looking at contribution guidelines from https://github.com/HugoGresse/open-feedback?tab=readme-ov-file#you-want-to-contribute- but it didn't lead anywhere_