### PR TITLE
Feedback app: add extra margin form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "open-feedback",
-    "version": "0.33.0",
+    "version": "0.34.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "open-feedback",
-            "version": "0.33.0",
+            "version": "0.34.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "open-feedback",
-    "version": "0.33.0",
+    "version": "0.34.0",
     "private": true,
     "homepage": "https://openfeedback.io/",
     "type": "module",

--- a/src/feedback/talk/Talk.jsx
+++ b/src/feedback/talk/Talk.jsx
@@ -51,9 +51,11 @@ export const Talk = () => {
     const talk = useSelector(getSelectedTalkSelector)
     const speakers = useSelector(getSpeakersForSelectedTalkSelector)
     const voteItems = useSelector(getProjectVoteItemsOrderedSelector)
-    const userVotes = useSelector(state => getActiveUserVotesByTalkAndVoteItemSelector(state, talkId))
+    const userVotes = useSelector((state) =>
+        getActiveUserVotesByTalkAndVoteItemSelector(state, talkId)
+    )
     const voteResults = useSelector((state) =>
-        getVoteResultSelectorSelector(state, displayVotes),
+        getVoteResultSelectorSelector(state, displayVotes)
     )
     const errorTalkLoad = useSelector(getTalkLoadErrorSelector)
     const errorVotePost = useSelector(getErrorVotePostSelector)
@@ -144,7 +146,7 @@ export const Talk = () => {
     return (
         <div>
             <TalkHeader talk={talk} speakers={speakers} />
-            <Grid container spacing={SPACING.LAYOUT}>
+            <Grid container spacing={SPACING.LAYOUT} sx={{ marginBottom: 6 }}>
                 {voteItems.map((voteItem, key) => (
                     <TalkVote
                         key={key}


### PR DESCRIPTION
- Add extra space before the footer in the voting form to differentiate the sponsor block and the actual form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds extra bottom spacing to the voting form grid on the talk page and bumps the app version to 0.34.0.
> 
> - **Frontend**:
>   - **Talk page layout**: Add `sx={ { marginBottom: 6 } }` to the `Grid` container in `src/feedback/talk/Talk.jsx` to create extra space before the footer.
> - **Release**:
>   - Bump version to `0.34.0` in `package.json` and `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0413d4ffaeab18b19617700574f35115dd9c794c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->