### PR TITLE
Fix qrcode not being transparent

### DIFF
--- a/src/baseComponents/QRCode.tsx
+++ b/src/baseComponents/QRCode.tsx
@@ -69,6 +69,9 @@ export const QRCode: React.FC<QRCodeProps> = ({
                 ...qrCodeConfig,
                 width: downloadSize,
                 height: downloadSize,
+                backgroundOptions: {
+                    color: 'transparent',
+                },
             }
 
             qrCode.current.update(downloadConfig)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets a transparent background when downloading QR codes (PNG/SVG) by overriding `backgroundOptions` during export.
> 
> - **Frontend**:
>   - **`src/baseComponents/QRCode.tsx`**: During download, override `backgroundOptions` to `{ color: 'transparent' }` so exported `png/svg` have transparent backgrounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fafed2fa1bd502ef6f0d313103df5848fd9a713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->