### PR TITLE
CI: inject VITE_* build env into Firebase deploys

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,6 +12,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
+        # Vite inlines these at build time; without them the deployed app
+        # ships an empty Firebase/runtime config.
+        env:
+          VITE_ADMIN_EMAIL: ${{ secrets.OF_VITE_ADMIN_EMAIL }}
+          VITE_RECAPTCHAV3_SITE_KEY: ${{ secrets.OF_VITE_RECAPTCHAV3_SITE_KEY }}
+          VITE_APPID: ${{ secrets.OF_VITE_APPID }}
+          VITE_API_KEY: ${{ secrets.OF_VITE_API_KEY }}
+          VITE_AUTH_DOMAIN: ${{ secrets.OF_VITE_AUTH_DOMAIN }}
+          VITE_DATABASE_URL: ${{ secrets.OF_VITE_DATABASE_URL }}
+          VITE_PROJECT_ID: ${{ secrets.OF_VITE_PROJECT_ID }}
+          VITE_STORAGE_BUCKET: ${{ secrets.OF_VITE_STORAGE_BUCKET }}
+          VITE_MEASUREMENT_ID: ${{ secrets.OF_VITE_MEASUREMENT_ID }}
+          VITE_SMALL_CHAT: ${{ secrets.OF_VITE_SMALL_CHAT }}
+          VITE_OPEN_SPONSORS: ${{ secrets.OF_VITE_OPEN_SPONSORS }}
+          VITE_EMULATORS: ${{ secrets.OF_VITE_EMULATORS }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,8 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
-        # Vite inlines these at build time; without them the deployed app
-        # ships an empty Firebase/runtime config.
+        # Vite inlines these into the client bundle at build time, so they are
+        # PUBLIC in the deployed app — never put server-only secrets here.
+        # Without them the deployed app ships an empty Firebase/runtime config.
         env:
           VITE_ADMIN_EMAIL: ${{ secrets.OF_VITE_ADMIN_EMAIL }}
           VITE_RECAPTCHAV3_SITE_KEY: ${{ secrets.OF_VITE_RECAPTCHAV3_SITE_KEY }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -14,6 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
+        # Vite inlines these at build time; without them the preview app
+        # ships an empty Firebase/runtime config.
+        env:
+          VITE_ADMIN_EMAIL: ${{ secrets.OF_VITE_ADMIN_EMAIL }}
+          VITE_RECAPTCHAV3_SITE_KEY: ${{ secrets.OF_VITE_RECAPTCHAV3_SITE_KEY }}
+          VITE_APPID: ${{ secrets.OF_VITE_APPID }}
+          VITE_API_KEY: ${{ secrets.OF_VITE_API_KEY }}
+          VITE_AUTH_DOMAIN: ${{ secrets.OF_VITE_AUTH_DOMAIN }}
+          VITE_DATABASE_URL: ${{ secrets.OF_VITE_DATABASE_URL }}
+          VITE_PROJECT_ID: ${{ secrets.OF_VITE_PROJECT_ID }}
+          VITE_STORAGE_BUCKET: ${{ secrets.OF_VITE_STORAGE_BUCKET }}
+          VITE_MEASUREMENT_ID: ${{ secrets.OF_VITE_MEASUREMENT_ID }}
+          VITE_SMALL_CHAT: ${{ secrets.OF_VITE_SMALL_CHAT }}
+          VITE_OPEN_SPONSORS: ${{ secrets.OF_VITE_OPEN_SPONSORS }}
+          VITE_EMULATORS: ${{ secrets.OF_VITE_EMULATORS }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -14,10 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
-        # Vite inlines these at build time; without them the preview app
-        # ships an empty Firebase/runtime config. Previews use the development
-        # config (OF_DEV_VITE_*); emulators are forced off because a deployed
-        # cloud preview cannot reach a local emulator suite.
+        # Vite inlines these into the client bundle at build time, so they are
+        # PUBLIC in the deployed preview — never put server-only secrets here.
+        # Without them the preview app ships an empty Firebase/runtime config.
+        # Previews use the development config (OF_DEV_VITE_*); emulators are
+        # forced off because a deployed cloud preview cannot reach a local
+        # emulator suite.
         env:
           VITE_ADMIN_EMAIL: ${{ secrets.OF_DEV_VITE_ADMIN_EMAIL }}
           VITE_RECAPTCHAV3_SITE_KEY: ${{ secrets.OF_DEV_VITE_RECAPTCHAV3_SITE_KEY }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -15,20 +15,22 @@ jobs:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
         # Vite inlines these at build time; without them the preview app
-        # ships an empty Firebase/runtime config.
+        # ships an empty Firebase/runtime config. Previews use the development
+        # config (OF_DEV_VITE_*); emulators are forced off because a deployed
+        # cloud preview cannot reach a local emulator suite.
         env:
-          VITE_ADMIN_EMAIL: ${{ secrets.OF_VITE_ADMIN_EMAIL }}
-          VITE_RECAPTCHAV3_SITE_KEY: ${{ secrets.OF_VITE_RECAPTCHAV3_SITE_KEY }}
-          VITE_APPID: ${{ secrets.OF_VITE_APPID }}
-          VITE_API_KEY: ${{ secrets.OF_VITE_API_KEY }}
-          VITE_AUTH_DOMAIN: ${{ secrets.OF_VITE_AUTH_DOMAIN }}
-          VITE_DATABASE_URL: ${{ secrets.OF_VITE_DATABASE_URL }}
-          VITE_PROJECT_ID: ${{ secrets.OF_VITE_PROJECT_ID }}
-          VITE_STORAGE_BUCKET: ${{ secrets.OF_VITE_STORAGE_BUCKET }}
-          VITE_MEASUREMENT_ID: ${{ secrets.OF_VITE_MEASUREMENT_ID }}
-          VITE_SMALL_CHAT: ${{ secrets.OF_VITE_SMALL_CHAT }}
-          VITE_OPEN_SPONSORS: ${{ secrets.OF_VITE_OPEN_SPONSORS }}
-          VITE_EMULATORS: ${{ secrets.OF_VITE_EMULATORS }}
+          VITE_ADMIN_EMAIL: ${{ secrets.OF_DEV_VITE_ADMIN_EMAIL }}
+          VITE_RECAPTCHAV3_SITE_KEY: ${{ secrets.OF_DEV_VITE_RECAPTCHAV3_SITE_KEY }}
+          VITE_APPID: ${{ secrets.OF_DEV_VITE_APPID }}
+          VITE_API_KEY: ${{ secrets.OF_DEV_VITE_API_KEY }}
+          VITE_AUTH_DOMAIN: ${{ secrets.OF_DEV_VITE_AUTH_DOMAIN }}
+          VITE_DATABASE_URL: ${{ secrets.OF_DEV_VITE_DATABASE_URL }}
+          VITE_PROJECT_ID: ${{ secrets.OF_DEV_VITE_PROJECT_ID }}
+          VITE_STORAGE_BUCKET: ${{ secrets.OF_DEV_VITE_STORAGE_BUCKET }}
+          VITE_MEASUREMENT_ID: ${{ secrets.OF_DEV_VITE_MEASUREMENT_ID }}
+          VITE_SMALL_CHAT: ${{ secrets.OF_DEV_VITE_SMALL_CHAT }}
+          VITE_OPEN_SPONSORS: ${{ secrets.OF_DEV_VITE_OPEN_SPONSORS }}
+          VITE_EMULATORS: 'false'
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Injects the `VITE_*` build-time environment into the Firebase deploy workflows.

## Why

`firebase-hosting-merge.yml` (live, on push to main) and `firebase-hosting-pull-request.yml` (PR previews) ran `npm run build` with **no environment**. Vite inlines `import.meta.env.VITE_*` at build time, so the deployed/preview app shipped an **empty Firebase + runtime config** (no API key, auth domain, project id, recaptcha, etc.).

## Changes

- Add an `env:` block to the build step of both workflows, mapping every `VITE_*` var from a prefixed repo secret (`OF_VITE_*`).
- The 12 secrets (`OF_VITE_API_KEY`, `OF_VITE_AUTH_DOMAIN`, `OF_VITE_PROJECT_ID`, …) were created from `.env.production.local`.

## Note

`#1665` already merged the workflows (without env), so the last live deploy shipped the empty config. After this merges, the next push to `main` redeploys with the correct env — or re-run the latest "Deploy to Firebase Hosting on merge" run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
