### PR TITLE
Add API endpoint to export event session votes

### DIFF
--- a/functions/src/api/routes/events/getVotes.spec.ts
+++ b/functions/src/api/routes/events/getVotes.spec.ts
@@ -14,7 +14,14 @@ const seededProject = {
     voteItems: [{ id: 'q1', name: 'Quality' }],
     _collections: {
         sessionVotes: [
-            { id: 'session1', q1: { uidA: { text: 'Great talk', plus: 2 } } },
+            {
+                id: 'session1',
+                // uidB has no `plus` — must default to 0, not "(undefined)".
+                q1: {
+                    uidA: { text: 'Great talk', plus: 2 },
+                    uidB: { text: 'Loved it' },
+                },
+            },
         ],
     },
 }
@@ -32,10 +39,10 @@ const openFeedbackJson = {
     speakers: { spk1: { name: 'Alice' } },
 }
 
-const stubFetch = (json: unknown = openFeedbackJson) =>
+const stubFetch = (json: unknown = openFeedbackJson, ok = true, status = 200) =>
     vi.stubGlobal(
         'fetch',
-        vi.fn(async () => ({ json: async () => json }))
+        vi.fn(async () => ({ ok, status, json: async () => json }))
     )
 
 // Stub the private-subcollection key resolution used by authenticateRequest:
@@ -76,7 +83,7 @@ const expectedRow = {
     speakersName: 'Alice',
     tags: 'frontend',
     trackTitle: 'Track A',
-    Quality: 'Great talk (2)',
+    Quality: 'Great talk (2), Loved it (0)',
 }
 
 describe('/events/:projectId/votes', () => {
@@ -158,6 +165,34 @@ describe('/events/:projectId/votes', () => {
         })
 
         expect(response.statusCode).toBe(404)
+        expect(JSON.parse(response.body).error).toBe('Event not found')
+    })
+
+    it('returns the same 404 for a non-existent event (not enumerable)', async () => {
+        mockOrgKey({ id: 'org_123' })
+
+        const response = await fastify.inject({
+            method: 'GET',
+            url: '/events/proj_missing/votes',
+            headers: { 'x-api-key': 'oforg_test-key' },
+        })
+
+        expect(response.statusCode).toBe(404)
+        // Identical message to the wrong-org case above: ids stay opaque.
+        expect(JSON.parse(response.body).error).toBe('Event not found')
+    })
+
+    it('returns 400 when the public data URL responds with an error', async () => {
+        stubFetch(openFeedbackJson, false, 502)
+        mockProjectKey()
+
+        const response = await fastify.inject({
+            method: 'GET',
+            url: '/events/proj_123/votes',
+            headers: { 'x-api-key': 'ofproj_test-key' },
+        })
+
+        expect(response.statusCode).toBe(400)
     })
 
     it('returns 400 when the event has no public data URL', async () => {

--- a/functions/src/api/routes/events/getVotes.spec.ts
+++ b/functions/src/api/routes/events/getVotes.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mockFirebaseAdminApp } from '../../../testUtils/firestoreMock'
+import { mockWhere } from 'firestore-vitest/mocks/firestore'
+
+// Event (project) doc as stored in Firestore, with the public-data URL and the
+// vote items + a seeded sessionVotes subcollection.
+const seededProject = {
+    id: 'proj_123',
+    name: 'Test Event',
+    owner: 'user_123',
+    members: ['user_123'],
+    organizationId: 'org_123',
+    config: { jsonUrl: 'https://data.example.test/openfeedback.json' },
+    voteItems: [{ id: 'q1', name: 'Quality' }],
+    _collections: {
+        sessionVotes: [
+            { id: 'session1', q1: { uidA: { text: 'Great talk', plus: 2 } } },
+        ],
+    },
+}
+
+// The event's public sessions/speakers JSON (fetched from config.jsonUrl).
+const openFeedbackJson = {
+    sessions: {
+        session1: {
+            title: 'Talk 1',
+            speakers: ['spk1'],
+            tags: ['frontend'],
+            trackTitle: 'Track A',
+        },
+    },
+    speakers: { spk1: { name: 'Alice' } },
+}
+
+const stubFetch = (json: unknown = openFeedbackJson) =>
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({ json: async () => json }))
+    )
+
+// Stub the private-subcollection key resolution used by authenticateRequest:
+// collectionGroup('private').where(...).limit(1).get(), grandparent = entity.
+const mockKeyResolves = (
+    parentCollection: string,
+    doc: Record<string, unknown>
+) => {
+    const entityDoc = { exists: true, id: doc.id as string, data: () => doc }
+    const entityRef = {
+        id: doc.id as string,
+        parent: { id: parentCollection },
+        get: () => entityDoc,
+    }
+    const integrationDoc = {
+        ref: {
+            id: 'integration',
+            parent: { parent: entityRef },
+            set: () => Promise.resolve(),
+        },
+    }
+    mockWhere.mockImplementation(() => ({
+        limit: () => ({
+            get: () => ({ empty: false, docs: [integrationDoc] }),
+        }),
+    }))
+}
+
+const mockProjectKey = (project = seededProject) =>
+    mockKeyResolves('projects', project)
+const mockOrgKey = (org: Record<string, unknown> = { id: 'org_123' }) =>
+    mockKeyResolves('organizations', org)
+
+const expectedRow = {
+    sessionId: 'session1',
+    title: 'Talk 1',
+    speakers: 'spk1',
+    speakersName: 'Alice',
+    tags: 'frontend',
+    trackTitle: 'Track A',
+    Quality: 'Great talk (2)',
+}
+
+describe('/events/:projectId/votes', () => {
+    let fastify: any
+
+    beforeEach(async () => {
+        mockFirebaseAdminApp({ projects: [seededProject] })
+        stubFetch()
+        const { createFastifyAPI } = await import('../../api')
+        fastify = await createFastifyAPI()
+    })
+
+    afterEach(async () => {
+        if (fastify) {
+            await fastify.close()
+        }
+        vi.unstubAllGlobals()
+        vi.clearAllMocks()
+    })
+
+    it('returns 401 when no API key is provided', async () => {
+        const response = await fastify.inject({
+            method: 'GET',
+            url: '/events/proj_123/votes',
+        })
+        expect(response.statusCode).toBe(401)
+    })
+
+    it('exports votes for the event matching a project key', async () => {
+        mockProjectKey()
+
+        const response = await fastify.inject({
+            method: 'GET',
+            url: '/events/proj_123/votes',
+            headers: { 'x-api-key': 'ofproj_test-key' },
+        })
+
+        expect(response.statusCode).toBe(200)
+        const body = JSON.parse(response.body)
+        expect(body.projectId).toBe('proj_123')
+        expect(body.sessionsCount).toBe(1)
+        expect(body.sessions[0]).toEqual(expectedRow)
+    })
+
+    it('rejects a project key for a different event with 404', async () => {
+        mockProjectKey({ ...seededProject, id: 'proj_other' })
+
+        const response = await fastify.inject({
+            method: 'GET',
+            url: '/events/proj_123/votes',
+            headers: { 'x-api-key': 'ofproj_test-key' },
+        })
+
+        expect(response.statusCode).toBe(404)
+    })
+
+    it('exports votes for an event in the organization (org key)', async () => {
+        mockOrgKey({ id: 'org_123' })
+
+        const response = await fastify.inject({
+            method: 'GET',
+            url: '/events/proj_123/votes',
+            headers: { 'x-api-key': 'oforg_test-key' },
+        })
+
+        expect(response.statusCode).toBe(200)
+        const body = JSON.parse(response.body)
+        expect(body.sessionsCount).toBe(1)
+        expect(body.sessions[0]).toEqual(expectedRow)
+    })
+
+    it('rejects an org key for an event in another organization with 404', async () => {
+        mockOrgKey({ id: 'org_999' })
+
+        const response = await fastify.inject({
+            method: 'GET',
+            url: '/events/proj_123/votes',
+            headers: { 'x-api-key': 'oforg_test-key' },
+        })
+
+        expect(response.statusCode).toBe(404)
+    })
+
+    it('returns 400 when the event has no public data URL', async () => {
+        const { config: _omit, ...noUrlProject } = seededProject
+        mockProjectKey(noUrlProject as typeof seededProject)
+
+        const response = await fastify.inject({
+            method: 'GET',
+            url: '/events/proj_123/votes',
+            headers: { 'x-api-key': 'ofproj_test-key' },
+        })
+
+        expect(response.statusCode).toBe(400)
+    })
+})

--- a/functions/src/api/routes/events/getVotes.ts
+++ b/functions/src/api/routes/events/getVotes.ts
@@ -54,10 +54,21 @@ export const getEventVotesRoute: FastifyPluginAsync = async (server) => {
                 }
                 project = request.project as unknown as ExportableProject
             } else if (request.organization) {
-                const resolved = await ProjectDao.getProjectFromId(
-                    server.firebase,
-                    projectId
-                )
+                // Resolve the event and confirm it belongs to this org. A
+                // missing project and a wrong-org project must look identical
+                // (same 404 message) so event ids stay non-enumerable.
+                let resolved
+                try {
+                    resolved = await ProjectDao.getProjectFromId(
+                        server.firebase,
+                        projectId
+                    )
+                } catch (error) {
+                    if (error instanceof NotFoundError) {
+                        throw new NotFoundError('Event not found')
+                    }
+                    throw error
+                }
                 if (resolved.organizationId !== request.organization.id) {
                     throw new NotFoundError('Event not found')
                 }

--- a/functions/src/api/routes/events/getVotes.ts
+++ b/functions/src/api/routes/events/getVotes.ts
@@ -1,0 +1,82 @@
+import { FastifyPluginAsync } from 'fastify'
+import { Type } from '@sinclair/typebox'
+import { ErrorSchema, IdSchema } from '../../schemas'
+import { authenticateRequest } from '../../plugins/apiKeyPlugin'
+import { ProjectDao } from '../../dao/ProjectDao'
+import { NotFoundError } from '../../others/Errors'
+import {
+    buildEventVotesExport,
+    ExportableProject,
+} from '../../services/exportEventVotes'
+
+const ParamsSchema = Type.Object({
+    projectId: IdSchema,
+})
+
+const EventVotesResponseSchema = Type.Object({
+    projectId: IdSchema,
+    sessionsCount: Type.Integer({ minimum: 0 }),
+    // Each row has fixed session fields plus one column per vote item, so the
+    // shape is open (additionalProperties).
+    sessions: Type.Array(Type.Record(Type.String(), Type.Any())),
+})
+
+export const getEventVotesRoute: FastifyPluginAsync = async (server) => {
+    server.get(
+        '/:projectId/votes',
+        {
+            schema: {
+                description:
+                    'Export all session votes for an event (project). ' +
+                    'Accepts an event API key (`ofproj_`) for its own event, ' +
+                    'or an organization key (`oforg_`) for any event in that ' +
+                    'organization.',
+                tags: ['Events'],
+                params: ParamsSchema,
+                response: {
+                    200: EventVotesResponseSchema,
+                    400: ErrorSchema,
+                    401: ErrorSchema,
+                    404: ErrorSchema,
+                },
+            },
+            preHandler: authenticateRequest,
+        },
+        async (request) => {
+            const { projectId } = request.params as { projectId: string }
+
+            // Authorize against the authenticated key. Use 404 (not 403) on a
+            // mismatch so we never reveal which event ids exist.
+            let project: ExportableProject
+            if (request.project) {
+                if (request.project.id !== projectId) {
+                    throw new NotFoundError('Event not found')
+                }
+                project = request.project as unknown as ExportableProject
+            } else if (request.organization) {
+                const resolved = await ProjectDao.getProjectFromId(
+                    server.firebase,
+                    projectId
+                )
+                if (resolved.organizationId !== request.organization.id) {
+                    throw new NotFoundError('Event not found')
+                }
+                project = resolved as unknown as ExportableProject
+            } else {
+                // authenticateRequest guarantees one of the two; defensive only.
+                throw new NotFoundError('Event not found')
+            }
+
+            const sessions = await buildEventVotesExport(
+                server.firebase,
+                project
+            )
+
+            return {
+                projectId,
+                sessionsCount: sessions.length,
+                sessions,
+            }
+        }
+    )
+}

--- a/functions/src/api/routes/events/index.ts
+++ b/functions/src/api/routes/events/index.ts
@@ -1,6 +1,8 @@
 import { FastifyPluginAsync } from 'fastify'
 import { getEventByApiKeyRoute } from './getByApiKey'
+import { getEventVotesRoute } from './getVotes'
 
 export const eventsRoutes: FastifyPluginAsync = async (server) => {
     await server.register(getEventByApiKeyRoute)
+    await server.register(getEventVotesRoute)
 }

--- a/functions/src/api/services/exportEventVotes.ts
+++ b/functions/src/api/services/exportEventVotes.ts
@@ -1,0 +1,123 @@
+import { App as FirebaseApp } from 'firebase-admin/app'
+import { getFirestore } from 'firebase-admin/firestore'
+import { BadRequestError } from '../others/Errors'
+
+interface VoteItem {
+    id: string
+    name: string
+}
+
+// The fields of a project doc this export needs. The project doc carries more,
+// but only these matter for building the vote export.
+export interface ExportableProject {
+    id: string
+    voteItems?: VoteItem[]
+    config?: { jsonUrl?: string }
+}
+
+export interface EventVoteRow {
+    sessionId: string
+    title?: string
+    speakers?: string
+    speakersName?: string
+    tags?: string
+    trackTitle?: string
+    // One extra column per vote item, keyed by the vote item name.
+    [voteColumn: string]: string | undefined
+}
+
+interface OpenFeedbackData {
+    sessions: Record<string, Session>
+    speakers: Record<string, { name?: string }>
+}
+
+interface Session {
+    title?: string
+    speakers?: string[]
+    tags?: string[]
+    trackTitle?: string
+}
+
+// Turn a single sessionVotes value into a flat string. A value is either a
+// scalar or a map of vote entries shaped like { text, plus }.
+const voteValueToString = (voteResult: unknown): string => {
+    if (typeof voteResult !== 'object' || voteResult === null) {
+        return String(voteResult)
+    }
+    return Object.values(
+        voteResult as Record<string, { text?: string; plus?: number }>
+    )
+        .filter((v) => !!v?.text)
+        .map((v) => `${v.text} (${v.plus})`)
+        .join(', ')
+        .replaceAll('\n', ' ')
+}
+
+/**
+ * Build the per-session vote export for an event (project), reusing the core
+ * transformation of scripts/exportAllEventVotes.ts: read the event's public
+ * sessions/speakers JSON, then join each session with its `sessionVotes` doc
+ * and flatten votes into columns keyed by vote-item name.
+ *
+ * Returns plain rows (no CSV/file IO — that stays in the script).
+ */
+export const buildEventVotesExport = async (
+    firebaseApp: FirebaseApp,
+    project: ExportableProject
+): Promise<EventVoteRow[]> => {
+    const jsonUrl = project.config?.jsonUrl
+    if (!jsonUrl) {
+        throw new BadRequestError(
+            'This event has no public data URL (config.jsonUrl); nothing to export.'
+        )
+    }
+
+    const db = getFirestore(firebaseApp)
+    const data = (await fetch(jsonUrl).then((res) =>
+        res.json()
+    )) as OpenFeedbackData
+
+    const sessions = Object.keys(data.sessions || {}).map((id) => ({
+        id,
+        ...data.sessions[id],
+    }))
+    const voteItems = project.voteItems || []
+
+    const rows: EventVoteRow[] = []
+    for (const session of sessions) {
+        const sessionVotes = (await db
+            .collection('projects')
+            .doc(project.id)
+            .collection('sessionVotes')
+            .doc(session.id)
+            .get()
+            .then((doc) => doc.data())) as Record<string, unknown> | undefined
+
+        const speakersName = (session.speakers || [])
+            .map((speakerId) => data.speakers?.[speakerId]?.name)
+            .filter((name): name is string => !!name)
+            .join(', ')
+
+        const voteColumns = Object.keys(sessionVotes || {}).reduce<
+            Record<string, string>
+        >((acc, key) => {
+            const voteItem = voteItems.find((item) => item.id === key)
+            if (voteItem?.name) {
+                acc[voteItem.name] = voteValueToString(sessionVotes![key])
+            }
+            return acc
+        }, {})
+
+        rows.push({
+            sessionId: session.id,
+            title: session.title,
+            speakers: (session.speakers || []).join(', '),
+            speakersName,
+            tags: (session.tags || []).join(', '),
+            trackTitle: session.trackTitle,
+            ...voteColumns,
+        })
+    }
+
+    return rows
+}

--- a/functions/src/api/services/exportEventVotes.ts
+++ b/functions/src/api/services/exportEventVotes.ts
@@ -48,7 +48,7 @@ const voteValueToString = (voteResult: unknown): string => {
         voteResult as Record<string, { text?: string; plus?: number }>
     )
         .filter((v) => !!v?.text)
-        .map((v) => `${v.text} (${v.plus})`)
+        .map((v) => `${v.text} (${v.plus ?? 0})`)
         .join(', ')
         .replaceAll('\n', ' ')
 }
@@ -73,51 +73,81 @@ export const buildEventVotesExport = async (
     }
 
     const db = getFirestore(firebaseApp)
-    const data = (await fetch(jsonUrl).then((res) =>
-        res.json()
-    )) as OpenFeedbackData
+    const data = await fetchEventData(jsonUrl)
 
     const sessions = Object.keys(data.sessions || {}).map((id) => ({
         id,
         ...data.sessions[id],
     }))
-    const voteItems = project.voteItems || []
+    // Index vote items by id once instead of re-scanning per session.
+    const voteItemsById = new Map(
+        (project.voteItems || []).map((item) => [item.id, item])
+    )
 
-    const rows: EventVoteRow[] = []
-    for (const session of sessions) {
-        const sessionVotes = (await db
-            .collection('projects')
-            .doc(project.id)
-            .collection('sessionVotes')
-            .doc(session.id)
-            .get()
-            .then((doc) => doc.data())) as Record<string, unknown> | undefined
+    // Fetch every session's votes concurrently; sequential awaits would be slow
+    // and risk route timeouts on events with many sessions. Promise.all keeps
+    // the original session order.
+    return Promise.all(
+        sessions.map(async (session) => {
+            const sessionVotes = (await db
+                .collection('projects')
+                .doc(project.id)
+                .collection('sessionVotes')
+                .doc(session.id)
+                .get()
+                .then((doc) => doc.data())) as
+                | Record<string, unknown>
+                | undefined
 
-        const speakersName = (session.speakers || [])
-            .map((speakerId) => data.speakers?.[speakerId]?.name)
-            .filter((name): name is string => !!name)
-            .join(', ')
+            const speakersName = (session.speakers || [])
+                .map((speakerId) => data.speakers?.[speakerId]?.name)
+                .filter((name): name is string => !!name)
+                .join(', ')
 
-        const voteColumns = Object.keys(sessionVotes || {}).reduce<
-            Record<string, string>
-        >((acc, key) => {
-            const voteItem = voteItems.find((item) => item.id === key)
-            if (voteItem?.name) {
-                acc[voteItem.name] = voteValueToString(sessionVotes![key])
+            const voteColumns = Object.keys(sessionVotes || {}).reduce<
+                Record<string, string>
+            >((acc, key) => {
+                const voteItem = voteItemsById.get(key)
+                if (voteItem?.name) {
+                    acc[voteItem.name] = voteValueToString(sessionVotes![key])
+                }
+                return acc
+            }, {})
+
+            return {
+                sessionId: session.id,
+                title: session.title,
+                speakers: (session.speakers || []).join(', '),
+                speakersName,
+                tags: (session.tags || []).join(', '),
+                trackTitle: session.trackTitle,
+                ...voteColumns,
             }
-            return acc
-        }, {})
-
-        rows.push({
-            sessionId: session.id,
-            title: session.title,
-            speakers: (session.speakers || []).join(', '),
-            speakersName,
-            tags: (session.tags || []).join(', '),
-            trackTitle: session.trackTitle,
-            ...voteColumns,
         })
-    }
+    )
+}
 
-    return rows
+// Load the event's public sessions/speakers JSON, turning a bad/expired URL or
+// unparseable body into a 400 instead of an opaque 500.
+const fetchEventData = async (jsonUrl: string): Promise<OpenFeedbackData> => {
+    let response: Response
+    try {
+        response = await fetch(jsonUrl)
+    } catch {
+        throw new BadRequestError(
+            'Could not reach the event public data URL (config.jsonUrl).'
+        )
+    }
+    if (!response.ok) {
+        throw new BadRequestError(
+            `The event public data URL returned ${response.status}.`
+        )
+    }
+    try {
+        return (await response.json()) as OpenFeedbackData
+    } catch {
+        throw new BadRequestError(
+            'The event public data URL did not return valid JSON.'
+        )
+    }
 }


### PR DESCRIPTION
## What

Adds `GET /events/:projectId/votes` to the public API — exports every session's votes for an event as JSON.

Reuses the **core transformation** of `scripts/exportAllEventVotes.ts`, ported into `functions/src/api/services/exportEventVotes.ts`:
- fetch the event's public sessions/speakers JSON (`config.jsonUrl`),
- join each session with its `projects/{id}/sessionVotes/{sessionId}` doc,
- flatten votes into columns keyed by vote-item **name** (e.g. `"Quality": "Great talk (2)"`).

The CSV/file IO stays in the script; the API returns `{ projectId, sessionsCount, sessions[] }`.

## Auth — both key types, scoped

Accepts either key via the existing `authenticateRequest`:
- **Event key (`ofproj_`)** → only its own event (`request.project.id` must match the path).
- **Org key (`oforg_`)** → any event whose `organizationId` matches the org.

Mismatches return **404** (not 403) so event ids stay non-enumerable.

## Hardening vs the script

The script assumed well-formed data; the service guards: missing `config.jsonUrl` → 400, missing speakers, and vote items that don't map to a question are skipped instead of throwing.

## Tests

`getVotes.spec.ts` — 6 cases:
- no key → 401
- project key match → 200 + exported row
- project key, different event → 404
- org key, event in org → 200
- org key, event in another org → 404
- missing public data URL → 400

Functions build ✓ · lint ✓ · API tests 20/20 ✓

## Notes / possible follow-ups
- Could add `?format=csv` later (the row shape is already CSV-ready).
- The standalone script wasn't refactored to import this service (it lives outside the functions package with its own Firestore init); can unify later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)