### PR TITLE
Return numeric vote counts as numbers in the votes export

### DIFF
--- a/functions/src/api/routes/events/getVotes.spec.ts
+++ b/functions/src/api/routes/events/getVotes.spec.ts
@@ -11,7 +11,10 @@ const seededProject = {
     members: ['user_123'],
     organizationId: 'org_123',
     config: { jsonUrl: 'https://data.example.test/openfeedback.json' },
-    voteItems: [{ id: 'q1', name: 'Quality' }],
+    voteItems: [
+        { id: 'q1', name: 'Quality' },
+        { id: 'q2', name: 'Score' },
+    ],
     _collections: {
         sessionVotes: [
             {
@@ -21,6 +24,8 @@ const seededProject = {
                     uidA: { text: 'Great talk', plus: 2 },
                     uidB: { text: 'Loved it' },
                 },
+                // Count-type vote: a numeric tally, must stay a number.
+                q2: 22,
             },
         ],
     },
@@ -84,6 +89,7 @@ const expectedRow = {
     tags: 'frontend',
     trackTitle: 'Track A',
     Quality: 'Great talk (2), Loved it (0)',
+    Score: 22,
 }
 
 describe('/events/:projectId/votes', () => {
@@ -126,6 +132,9 @@ describe('/events/:projectId/votes', () => {
         expect(body.projectId).toBe('proj_123')
         expect(body.sessionsCount).toBe(1)
         expect(body.sessions[0]).toEqual(expectedRow)
+        // Count-type votes serialize as JSON numbers, not strings.
+        expect(typeof body.sessions[0].Score).toBe('number')
+        expect(typeof body.sessions[0].Quality).toBe('string')
     })
 
     it('rejects a project key for a different event with 404', async () => {

--- a/functions/src/api/services/exportEventVotes.ts
+++ b/functions/src/api/services/exportEventVotes.ts
@@ -22,8 +22,9 @@ export interface EventVoteRow {
     speakersName?: string
     tags?: string
     trackTitle?: string
-    // One extra column per vote item, keyed by the vote item name.
-    [voteColumn: string]: string | undefined
+    // One extra column per vote item, keyed by the vote item name. Count-type
+    // votes (boolean/rating tallies) are numbers; text votes are strings.
+    [voteColumn: string]: string | number | undefined
 }
 
 interface OpenFeedbackData {
@@ -38,9 +39,13 @@ interface Session {
     trackTitle?: string
 }
 
-// Turn a single sessionVotes value into a flat string. A value is either a
-// scalar or a map of vote entries shaped like { text, plus }.
-const voteValueToString = (voteResult: unknown): string => {
+// Turn a single sessionVotes value into a column value. Count-type votes are
+// numeric tallies (kept as numbers); text votes are a map of { text, plus }
+// entries (flattened to a string).
+const voteValueToColumn = (voteResult: unknown): string | number => {
+    if (typeof voteResult === 'number') {
+        return voteResult
+    }
     if (typeof voteResult !== 'object' || voteResult === null) {
         return String(voteResult)
     }
@@ -105,11 +110,11 @@ export const buildEventVotesExport = async (
                 .join(', ')
 
             const voteColumns = Object.keys(sessionVotes || {}).reduce<
-                Record<string, string>
+                Record<string, string | number>
             >((acc, key) => {
                 const voteItem = voteItemsById.get(key)
                 if (voteItem?.name) {
-                    acc[voteItem.name] = voteValueToString(sessionVotes![key])
+                    acc[voteItem.name] = voteValueToColumn(sessionVotes![key])
                 }
                 return acc
             }, {})


### PR DESCRIPTION
## Problem

`GET /events/:projectId/votes` returned count-type vote tallies as strings:

```json
"Drôle/original 😃": "10",
"Super intéressant 👍": "22",
```

These should be JSON numbers. (Text votes like `"Commentaire": "Bravo (1)"` are correctly strings.)

## Cause

`voteValueToString` ran every scalar value through `String(...)`, turning numeric tallies into strings.

## Fix

- Numeric vote results are kept as numbers; text-vote maps are still flattened to a formatted string (`renamed to voteValueToColumn`, returns `string | number`).
- `EventVoteRow` column type widened to `string | number`.
- The `Type.Any()` response schema already serializes numbers as numbers.

After:
```json
"Super intéressant 👍": 22,
"Commentaire": "Bravo (1)"
```

## Tests

Extended the votes export test with a numeric count vote item (`Score: 22`) and assertions that count votes serialize as `number` and text votes as `string`.

Functions build ✓ · API tests 22/22 ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)